### PR TITLE
feat(hooks): add cross-agent pre-plan guardrails hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.4.2"
+version = "0.5.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, and Copilot"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -1,3 +1,3 @@
 """klaussy — Claude Code boilerplate generator."""
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"

--- a/src/klaussy/agents/backends.py
+++ b/src/klaussy/agents/backends.py
@@ -31,7 +31,7 @@ from klaussy.agents.hooks import (
     gemini_hooks,
 )
 from klaussy.checklist import generate_checklist
-from klaussy.hooks import scaffold_hooks
+from klaussy.hooks import read_pre_plan_guidance, scaffold_hooks
 from klaussy.settings import SENSITIVE_PATTERNS, _detect_stack, generate_settings
 
 console = Console()
@@ -596,6 +596,16 @@ class AntigravityBackend(GenericBackend):
                 force=force,
                 what=f"{ANTIGRAVITY_PLUGIN}/rules/{rule.stem}.md",
             )
+        # Pre-plan guardrails: Antigravity hooks return only allow/deny (no
+        # context injection), so unlike the other agents the guidance can't ride
+        # a hook. It lands instead as an always-applied developer-rules file that
+        # Antigravity auto-indexes from the workspace root.
+        self._write(
+            repo / ".antigravityrules",
+            read_pre_plan_guidance(),
+            force=force,
+            what=".antigravityrules",
+        )
 
     def emit_settings(self, repo, *, force):
         # Best-effort: Antigravity's terminal allow/deny lists are primarily IDE

--- a/src/klaussy/agents/hooks.py
+++ b/src/klaussy/agents/hooks.py
@@ -23,12 +23,14 @@ from klaussy.hooks import (
     _detect_comment_check_command,
     _detect_format_command,
     _detect_lint_command,
+    read_pre_plan_guidance,
 )
 
 console = Console()
 
 COMMIT_GUARD = "klaussy_commit_guard.py"
 READ_GUARD = "klaussy_read_guard.py"
+GUIDANCE_GUARD = "klaussy_plan_guidance.py"
 
 
 def _hook_python() -> str:
@@ -71,6 +73,22 @@ def _install_script(
             '"__KLAUSSY_COMMENT_CHECK_CMD__"', _python_literal(comment_check_cmd)
         )
     )
+    dest.write_text(content)
+    dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _install_guidance_script(repo: Path, relpath: str, dialect: str) -> None:
+    """Copy the pre-plan guidance injector, baking in the text + dialect."""
+    dest = repo / relpath
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    content = (
+        resources.files("klaussy")
+        .joinpath("templates/hooks/multi/plan_guidance.py")
+        .read_text()
+    )
+    content = content.replace(
+        '"__KLAUSSY_GUIDANCE__"', _python_literal(read_pre_plan_guidance())
+    ).replace('"__KLAUSSY_DIALECT__"', _python_literal(dialect))
     dest.write_text(content)
     dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
@@ -123,13 +141,21 @@ def gemini_hooks(repo: Path, *, force: bool) -> None:
     if "hooks" in settings and not force:
         console.print(f"[yellow]⚠ [{label}] hooks already configured; use --force.[/yellow]")
         return
+    # BeforeAgent fires after the prompt, before planning — the earliest point
+    # Gemini can inject context (BeforeTool can't). Gemini has no plan tool, so
+    # the guidance lands each turn rather than only on plan entry.
+    _install_guidance_script(repo, f"{hooks_dir}/{GUIDANCE_GUARD}", "gemini")
+    guidance_cmd = {"type": "command",
+                    "command": f"{py} {hooks_dir}/{GUIDANCE_GUARD}",
+                    "timeout": 60000}
     settings["hooks"] = {
+        "BeforeAgent": [{"hooks": [guidance_cmd]}],
         "BeforeTool": before,
         "AfterTool": [{"matcher": "web_fetch", "hooks": [read_cmd]}],
     }
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
-    _report(label, bool(fmt or lint or com), read=True, web=True)
+    _report(label, bool(fmt or lint or com), read=True, web=True, plan=True)
 
 
 def cursor_hooks(repo: Path, *, force: bool) -> None:
@@ -156,73 +182,91 @@ def cursor_hooks(repo: Path, *, force: bool) -> None:
         {"command": f"{hooks_dir}/{READ_GUARD}", "type": "command",
          "failClosed": True}
     ]
+    # Cursor's beforeSubmitPrompt is block-only; sessionStart is its sole
+    # context-injection event, so the guidance lands once per session. Not
+    # failClosed — a guidance hiccup must never wedge the session.
+    _install_guidance_script(repo, f"{hooks_dir}/{GUIDANCE_GUARD}", "cursor")
+    hooks["sessionStart"] = [
+        {"command": f"{hooks_dir}/{GUIDANCE_GUARD}", "type": "command"}
+    ]
 
     if _write_json(repo / ".cursor" / "hooks.json", {"version": 1, "hooks": hooks},
                    force=force, label=label):
-        _report(label, bool(fmt or lint or com), read=True, web=False)
+        _report(label, bool(fmt or lint or com), read=True, web=False, plan=True)
 
 
 def codex_hooks(repo: Path, *, force: bool) -> None:
-    """Codex: PreToolUse on Bash only — no pre-read or web-fetch hook surface."""
+    """Codex: UserPromptSubmit plan-guidance + PreToolUse commit guard on Bash."""
     label = "Codex CLI"
     fmt, lint, com = _commit_cmds(repo)
     hooks_dir = ".codex/hooks"
+    py = _hook_python()
 
-    if not (fmt or lint or com):
-        console.print(
-            f"[dim][{label}] no lint/format command detected — no hooks to wire.[/dim]"
-        )
-        return
-    _install_script(
-        repo, f"{hooks_dir}/{COMMIT_GUARD}", "commit_guard.py",
-        format_cmd=fmt, lint_cmd=lint, comment_check_cmd=com,
-    )
-    config = {
-        "hooks": {
-            "PreToolUse": [{
-                "matcher": "Bash",
-                "hooks": [{"type": "command",
-                           "command": f"{_hook_python()} {hooks_dir}/{COMMIT_GUARD}",
-                           "timeout": 60}],
-            }]
-        }
+    # Codex has no plan tool, but reports permission_mode ("plan") on stdin and
+    # can inject additionalContext from UserPromptSubmit — so the guidance script
+    # self-gates to plan mode. Wired unconditionally (independent of lint/format).
+    _install_guidance_script(repo, f"{hooks_dir}/{GUIDANCE_GUARD}", "codex")
+    hooks_cfg: dict = {
+        "UserPromptSubmit": [{
+            "hooks": [{"type": "command",
+                       "command": f"{py} {hooks_dir}/{GUIDANCE_GUARD}",
+                       "timeout": 60}],
+        }]
     }
-    if _write_json(repo / ".codex" / "hooks.json", config, force=force, label=label):
-        _report(label, True, read=False, web=False,
+    if fmt or lint or com:
+        _install_script(
+            repo, f"{hooks_dir}/{COMMIT_GUARD}", "commit_guard.py",
+            format_cmd=fmt, lint_cmd=lint, comment_check_cmd=com,
+        )
+        hooks_cfg["PreToolUse"] = [{
+            "matcher": "Bash",
+            "hooks": [{"type": "command",
+                       "command": f"{py} {hooks_dir}/{COMMIT_GUARD}",
+                       "timeout": 60}],
+        }]
+
+    if _write_json(repo / ".codex" / "hooks.json", {"hooks": hooks_cfg},
+                   force=force, label=label):
+        _report(label, bool(fmt or lint or com), read=False, web=False, plan=True,
                 read_note="Codex has no pre-file-read hook event")
 
 
 def copilot_hooks(repo: Path, *, force: bool) -> None:
-    """Copilot: preToolUse (fail-closed) — wire only the defensive commit guard."""
+    """Copilot: sessionStart plan-guidance + preToolUse (fail-closed) commit guard."""
     label = "GitHub Copilot"
     fmt, lint, com = _commit_cmds(repo)
     hooks_dir = ".github/hooks"
 
-    if not (fmt or lint or com):
-        console.print(
-            f"[dim][{label}] no lint/format command detected — no hooks to wire.[/dim]"
-        )
-        return
-    _install_script(
-        repo, f"{hooks_dir}/{COMMIT_GUARD}", "commit_guard.py",
-        format_cmd=fmt, lint_cmd=lint, comment_check_cmd=com,
-    )
     # Copilot command hooks support an OS split: `bash` (Linux/macOS) and
-    # `powershell` (Windows). Use both so the guard runs regardless of platform.
-    config = {
-        "version": 1,
-        "hooks": {
-            "preToolUse": [{
-                "type": "command",
-                "bash": f"python3 {hooks_dir}/{COMMIT_GUARD}",
-                "powershell": f"python {hooks_dir}/{COMMIT_GUARD}",
-                "timeoutSec": 60,
-            }]
-        },
+    # `powershell` (Windows). Use both so hooks run regardless of platform.
+    # sessionStart is Copilot's only context-injection event (preToolUse and
+    # userPromptSubmitted can't inject), so the guidance lands once per session.
+    # Wired unconditionally (independent of lint/format).
+    _install_guidance_script(repo, f"{hooks_dir}/{GUIDANCE_GUARD}", "copilot")
+    hooks_cfg: dict = {
+        "sessionStart": [{
+            "type": "command",
+            "bash": f"python3 {hooks_dir}/{GUIDANCE_GUARD}",
+            "powershell": f"python {hooks_dir}/{GUIDANCE_GUARD}",
+            "timeoutSec": 60,
+        }]
     }
+    if fmt or lint or com:
+        _install_script(
+            repo, f"{hooks_dir}/{COMMIT_GUARD}", "commit_guard.py",
+            format_cmd=fmt, lint_cmd=lint, comment_check_cmd=com,
+        )
+        hooks_cfg["preToolUse"] = [{
+            "type": "command",
+            "bash": f"python3 {hooks_dir}/{COMMIT_GUARD}",
+            "powershell": f"python {hooks_dir}/{COMMIT_GUARD}",
+            "timeoutSec": 60,
+        }]
+
+    config = {"version": 1, "hooks": hooks_cfg}
     if _write_json(repo / ".github" / "hooks" / "klaussy-guards.json", config,
                    force=force, label=label):
-        _report(label, True, read=False, web=False,
+        _report(label, bool(fmt or lint or com), read=False, web=False, plan=True,
                 read_note="Copilot preToolUse is fail-closed; read-injection "
                           "tool args are unconfirmed, so it's omitted")
 
@@ -291,6 +335,7 @@ def _report(
     *,
     read: bool,
     web: bool,
+    plan: bool = False,
     read_note: str | None = None,
 ) -> None:
     parts = []
@@ -300,6 +345,8 @@ def _report(
         parts.append("read-injection")
     if web:
         parts.append("web-fetch")
+    if plan:
+        parts.append("plan-guidance")
     wired = ", ".join(parts) if parts else "none"
     console.print(f"[green]✔ [{label}] hooks wired: {wired}[/green]")
     if not commit:

--- a/src/klaussy/hooks.py
+++ b/src/klaussy/hooks.py
@@ -17,6 +17,22 @@ COMMIT_GUARD_SCRIPT_NAME = "git_commit_guard.py"
 COMMIT_GUARD_RELPATH = f".claude/hooks/{COMMIT_GUARD_SCRIPT_NAME}"
 COMMIT_GUARD_COMMAND = f"python3 {COMMIT_GUARD_RELPATH}"
 
+PLAN_GUIDANCE_SCRIPT_NAME = "plan_guidance.py"
+PLAN_GUIDANCE_RELPATH = f".claude/hooks/{PLAN_GUIDANCE_SCRIPT_NAME}"
+PLAN_GUIDANCE_COMMAND = f"python3 {PLAN_GUIDANCE_RELPATH}"
+
+
+def read_pre_plan_guidance() -> str:
+    """The canonical pre-plan guardrails text.
+
+    Single source of truth shared by every agent's plan-guidance hook (baked
+    into the installed script) and Antigravity's always-on developer-rules file
+    (which has no hook injection surface). Edit `templates/pre_plan_guidance.md`
+    to change the guidance everywhere at once.
+    """
+    source = resources.files("klaussy").joinpath("templates/pre_plan_guidance.md")
+    return source.read_text().rstrip() + "\n"
+
 
 def _detect_lint_command(repo: Path) -> str | None:
     """Detect the project's lint command."""
@@ -106,6 +122,24 @@ def _install_commit_guard_script(
     return dest
 
 
+def _install_plan_guidance_script(repo: Path, dialect: str) -> Path:
+    """Render the pre-plan guidance injector with text + dialect baked in."""
+    dest = repo / PLAN_GUIDANCE_RELPATH
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    source = resources.files("klaussy").joinpath(
+        "templates/hooks/multi/plan_guidance.py"
+    )
+    content = source.read_text()
+    content = content.replace(
+        '"__KLAUSSY_GUIDANCE__"', _python_literal(read_pre_plan_guidance())
+    )
+    content = content.replace('"__KLAUSSY_DIALECT__"', _python_literal(dialect))
+    dest.write_text(content)
+    mode = dest.stat().st_mode
+    dest.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return dest
+
+
 def scaffold_hooks(*, repo: Path, force: bool = False) -> Path:
     """Add hook configurations to .claude/settings.json."""
     repo = repo.resolve()
@@ -139,6 +173,18 @@ def scaffold_hooks(*, repo: Path, force: bool = False) -> Path:
             "hooks": [{"type": "command", "command": GUARD_COMMAND}],
         },
     ]
+
+    # Pre-plan guidance: PreToolUse on EnterPlanMode fires the instant plan mode
+    # opens, before Claude drafts the plan. The hook injects klaussy's guardrails
+    # (smallest change, only what's asked, suggest-then-wait) via additionalContext
+    # so they shape the plan itself.
+    _install_plan_guidance_script(repo, "claude")
+    pretooluse.append(
+        {
+            "matcher": "EnterPlanMode",
+            "hooks": [{"type": "command", "command": PLAN_GUIDANCE_COMMAND}],
+        }
+    )
     posttooluse: list[dict] = [
         {
             "matcher": "WebFetch",
@@ -171,6 +217,9 @@ def scaffold_hooks(*, repo: Path, force: bool = False) -> Path:
     settings_file.write_text(json.dumps(settings, indent=2) + "\n")
     console.print(f"[green]✔ Added hooks to {settings_file.relative_to(repo)}[/green]")
     console.print(f"[green]✔ Installed read-injection guard at {GUARD_RELPATH}[/green]")
+    console.print(
+        f"[green]✔ Installed pre-plan guidance hook at {PLAN_GUIDANCE_RELPATH}[/green]"
+    )
     if format_cmd or lint_cmd or comment_check_cmd:
         console.print(
             f"[green]✔ Installed git-commit guard at {COMMIT_GUARD_RELPATH}[/green]"

--- a/src/klaussy/templates/hooks/multi/plan_guidance.py
+++ b/src/klaussy/templates/hooks/multi/plan_guidance.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Cross-agent pre-plan guidance injector: feed klaussy's guardrails to the agent.
+
+Wired to each agent's earliest "before the model plans" event; coverage differs
+because each exposes a different injection surface:
+
+  * Claude Code  PreToolUse(EnterPlanMode)  -> injects the moment plan mode opens
+  * Codex        UserPromptSubmit           -> injects only when permission_mode == "plan"
+  * Gemini CLI   BeforeAgent                -> injects each turn, before planning
+  * Cursor       sessionStart               -> injects once per session
+  * Copilot      sessionStart               -> injects once per session
+
+Guidance text and DIALECT are baked in at scaffold time, so the script needs no
+arguments. Hardened to never crash or block: any unexpected payload or error
+prints nothing and exits 0.
+
+Edit GUIDANCE below (or re-run `klaussy hooks --force --agents <agent>`).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+# Baked in by klaussy at scaffold time.
+GUIDANCE: str = "__KLAUSSY_GUIDANCE__"
+DIALECT: str = "__KLAUSSY_DIALECT__"
+
+
+def _payload() -> dict:
+    """Read the hook's stdin JSON, tolerating empty or malformed input."""
+    try:
+        data = json.load(sys.stdin)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _emit(dialect: str, payload: dict) -> dict | None:
+    """Build the dialect-specific stdout object, or None to inject nothing.
+
+    `additionalContext` (camelCase) is the field Claude / Codex / Gemini /
+    Copilot read; Cursor uses `additional_context` (snake_case). The wrapping
+    object differs too, so each dialect is spelled out rather than guessed.
+    """
+    if dialect == "claude":
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "additionalContext": GUIDANCE,
+            }
+        }
+    if dialect == "codex":
+        # The EnterPlanMode matcher gates Claude; Codex has no plan tool, so gate
+        # on the permission_mode it reports on stdin instead.
+        if payload.get("permission_mode") != "plan":
+            return None
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": GUIDANCE,
+            }
+        }
+    if dialect == "gemini":
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "BeforeAgent",
+                "additionalContext": GUIDANCE,
+            }
+        }
+    if dialect == "cursor":
+        return {"additional_context": GUIDANCE}
+    if dialect == "copilot":
+        return {"additionalContext": GUIDANCE}
+    return None
+
+
+def main() -> int:
+    try:
+        out = _emit(DIALECT, _payload())
+        if out is not None:
+            print(json.dumps(out))
+    except Exception as exc:  # never crash — injecting nothing is always safe
+        print(f"klaussy plan-guidance: skipping ({exc})", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/klaussy/templates/pre_plan_guidance.md
+++ b/src/klaussy/templates/pre_plan_guidance.md
@@ -1,0 +1,16 @@
+# Pre-Plan Guardrails
+
+## 1. Scope & Execution Boundaries
+* **Task Strictness:** Only implement what the user's task explicitly asks for. Do not over-engineer or solve unmentioned problems.
+* **Smallest Necessary Change:** Always aim for the minimal amount of lines changed to safely fulfill the requirement. Do not perform unrelated refactoring.
+* **Interactive Guidance:** If you identify optimizations or alternative architectural routes, offer them as guidance *only*. **DO NOT** implement or write code for them until the user explicitly responds and approves them.
+
+## 2. Planning Mode Protocol
+* **Review Phase:** When generating an Implementation Plan, explicitly layout the changes and immediately halt.
+* **Wait for Consent:** Do not begin editing files, writing code, or calling execution tools until the user provides explicit written confirmation to proceed.
+
+## 3. Code & Testing Standards
+* **Repository Conventions:** Adhere strictly to the established patterns, syntax styles, file structures, and naming conventions already present in this repository.
+* **Comprehensive Testing:** Every code change requires corresponding test coverage. You must explicitly write test cases for:
+  * **Happy Path:** Expected, successful execution flows.
+  * **Error Paths:** Handled failures, invalid inputs, edge cases, and exceptions.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -831,6 +831,8 @@ class TestMultiAgentHooks:
         CodexBackend().emit_hooks(repo, force=True)
         cfg = json.loads((repo / ".codex" / "hooks.json").read_text())
         assert cfg["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
+        # Plan guidance rides UserPromptSubmit (Codex's injecting event).
+        assert "UserPromptSubmit" in cfg["hooks"]
         # No read guard (Codex has no pre-read hook surface).
         assert not (repo / ".codex" / "hooks" / "klaussy_read_guard.py").exists()
 
@@ -844,11 +846,15 @@ class TestMultiAgentHooks:
         assert "preToolUse" in cfg["hooks"]
 
     def test_no_lint_format_skips_commit_guard(self, tmp_path: Path):
-        # A bare repo (no pyproject/package.json) → no commit guard for codex.
+        # A bare repo (no pyproject/package.json) → no commit guard for codex,
+        # but the plan-guidance hook (UserPromptSubmit) still wires.
         from klaussy.agents.backends import CodexBackend
 
         CodexBackend().emit_hooks(tmp_path, force=True)
-        assert not (tmp_path / ".codex" / "hooks.json").exists()
+        cfg = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+        assert "UserPromptSubmit" in cfg["hooks"]
+        assert "PreToolUse" not in cfg["hooks"]
+        assert not (tmp_path / ".codex" / "hooks" / "klaussy_commit_guard.py").exists()
 
     # --- guard behavior (dialect-tolerant + never-crash) --------------------
 
@@ -911,6 +917,88 @@ class TestMultiAgentHooks:
         assert rg._extract_path({"file_path": "/b"}) == "/b"  # cursor top level
         assert rg._extract_path({"toolArgs": {"path": "/c"}}) == "/c"
         assert rg._extract_path({}) == ""
+
+    # --- pre-plan guidance hook ---------------------------------------------
+
+    def _emit_for(self, dialect: str, payload: dict):
+        """Drive the guidance injector's _emit for one dialect + payload."""
+        guard = self._load_guard("plan_guidance.py")
+        guard.GUIDANCE = "GUIDANCE-TEXT"
+        return guard._emit(dialect, payload)
+
+    def test_guidance_claude_injects_additional_context(self):
+        out = self._emit_for("claude", {})
+        assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert out["hookSpecificOutput"]["additionalContext"] == "GUIDANCE-TEXT"
+
+    def test_guidance_codex_gates_on_plan_mode(self):
+        # Inject only when the user is in plan mode; stay silent otherwise.
+        assert self._emit_for("codex", {"permission_mode": "plan"}) is not None
+        assert self._emit_for("codex", {"permission_mode": "default"}) is None
+        assert self._emit_for("codex", {}) is None
+
+    def test_guidance_dialect_output_shapes(self):
+        # Cursor uses snake_case at top level; the rest use camelCase nested.
+        assert self._emit_for("cursor", {})["additional_context"] == "GUIDANCE-TEXT"
+        for d in ("gemini", "copilot"):
+            out = self._emit_for(d, {})
+            ctx = out.get("additionalContext") or out["hookSpecificOutput"][
+                "additionalContext"
+            ]
+            assert ctx == "GUIDANCE-TEXT"
+        assert self._emit_for("unknown", {}) is None
+
+    def test_guidance_never_crashes_on_bad_stdin(self, monkeypatch):
+        import io
+
+        guard = self._load_guard("plan_guidance.py")
+        guard.GUIDANCE, guard.DIALECT = "G", "claude"
+        monkeypatch.setattr(guard.sys, "stdin", io.StringIO("not json"))
+        assert guard.main() == 0  # malformed payload → still allow, no crash
+
+    def test_claude_scaffolds_enter_plan_mode_hook(self, repo: Path):
+        from klaussy.hooks import scaffold_hooks
+
+        scaffold_hooks(repo=repo, force=True)
+        settings = json.loads((repo / ".claude" / "settings.json").read_text())
+        matchers = {e["matcher"] for e in settings["hooks"]["PreToolUse"]}
+        assert "EnterPlanMode" in matchers
+        script = repo / ".claude" / "hooks" / "plan_guidance.py"
+        assert script.stat().st_mode & 0o100  # executable
+        body = script.read_text()
+        assert "Pre-Plan Guardrails" in body  # guidance baked in
+        assert "'claude'" in body  # dialect baked in
+
+    def test_gemini_wires_before_agent_guidance(self, repo: Path):
+        from klaussy.agents.backends import GeminiBackend
+
+        GeminiBackend().emit_hooks(repo, force=True)
+        settings = json.loads((repo / ".gemini" / "settings.json").read_text())
+        assert "BeforeAgent" in settings["hooks"]
+        assert (repo / ".gemini" / "hooks" / "klaussy_plan_guidance.py").exists()
+
+    def test_cursor_and_copilot_wire_session_start_guidance(self, repo: Path):
+        from klaussy.agents.backends import CopilotBackend, CursorBackend
+
+        CursorBackend().emit_hooks(repo, force=True)
+        cur = json.loads((repo / ".cursor" / "hooks.json").read_text())
+        assert "sessionStart" in cur["hooks"]
+
+        CopilotBackend().emit_hooks(repo, force=True)
+        cop = json.loads(
+            (repo / ".github" / "hooks" / "klaussy-guards.json").read_text()
+        )
+        assert "sessionStart" in cop["hooks"]
+
+    def test_antigravity_writes_developer_rules(self, repo_with_claude_md: Path):
+        # Antigravity hooks can't inject context, so guidance lands as an
+        # always-applied developer-rules file at the workspace root.
+        from klaussy.agents.backends import AntigravityBackend
+
+        AntigravityBackend().emit_conventions(repo_with_claude_md, force=True)
+        rules = repo_with_claude_md / ".antigravityrules"
+        assert rules.exists()
+        assert "Pre-Plan Guardrails" in rules.read_text()
 
 
 class TestAdrSubReview:


### PR DESCRIPTION
## What

Injects klaussy's **pre-plan guardrails** (smallest necessary change, only what the task asks, suggest-then-wait, investigate first, comprehensive testing) the moment an agent begins planning — delivered through the best surface each backend actually exposes, verified against each vendor's hook docs.

| Agent | Mechanism | Gating |
|---|---|---|
| Claude Code | `PreToolUse` → `EnterPlanMode` → `additionalContext` | plan-entry |
| Codex | `UserPromptSubmit`, self-gated to `permission_mode == "plan"` | plan-mode |
| Gemini CLI | `BeforeAgent` → `additionalContext` | per-turn |
| Cursor | `sessionStart` → `additional_context` | per-session |
| Copilot | `sessionStart` → `additionalContext` | per-session |
| Antigravity | `.antigravityrules` developer-rules file (hooks can't inject) | always-on |

## How

- **New** `templates/pre_plan_guidance.md` — canonical guidance text (single source of truth).
- **New** `templates/hooks/multi/plan_guidance.py` — shared injector; text + dialect baked in at scaffold time, per-dialect JSON output, never crashes or blocks.
- Wired in `hooks.py` (Claude) and `agents/hooks.py` (Gemini/Codex/Cursor/Copilot); Antigravity gets `.antigravityrules` via `backends.py`.
- Codex & Copilot now always emit `hooks.json` for the guidance hook (commit guard stays conditional on lint/format detection).

## Tests

- 8 new plan-guidance tests + updated the Codex test for the new always-emit behavior.
- Full suite: **166 passed, 13 skipped**; `ruff check` clean.

Bumps version to **0.5.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)