### PR TITLE
feat: dependency gate, two new skills, shared session state (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.10.0]
+
+### Added
+
+- **Dependency gate hook** — a new cross-agent guard that blocks package-manager
+  commands adding a *new named* dependency (`pip install requests`, `npm install
+  lodash`, `poetry add`, `cargo add`, `go get`, …) so the agent confirms it's
+  actually needed before bloating the manifest. Bare manifest syncs (`npm
+  install`, `pip install -r requirements.txt`, `uv sync`) pass through untouched;
+  prefix a confirmed install with `KLAUSSY_DEPS_OK=1` to proceed. Wired into all
+  seven agents with a pre-shell hook (Claude, Gemini, Cursor, Codex, Copilot,
+  Antigravity, Cline).
+- **`adr-generator` skill** — drafts Architecture Decision Records, matching the
+  repo's existing ADR location and template (MADR/Nygard) or establishing one.
+- **`security-audit` skill** — a focused, diff-scoped security pass (secrets,
+  injection, SSRF, access control, unsafe deserialization, new/vulnerable
+  dependencies); narrower and deeper than the general `review` skill.
+- **Shared session state** — `klaussy init` scaffolds `.agents/session.json`, a
+  tool-neutral handoff note (branch, task, plan, known failures) any agent can
+  read at session start and update as work progresses, so switching between tools
+  doesn't mean re-discovering the active task. Live state is gitignored; the
+  committed `.agents/SESSION.md` documents the contract.
+
+### Fixed
+
+- Capability banners are now detected against the *adapted* skill body, so a
+  sub-agent / plan-mode mention inside a stripped dynamic-shell block no longer
+  triggers a spurious banner.
+
+## [0.9.0]
+
+### Added
+
+- **Aider (Ollama) backend** — model-agnostic, commonly run on a local Ollama
+  model. Emits a flat `CONVENTIONS.md` (project-wide conventions + inlined
+  path-scoped rules) wired into `.aider.conf.yml`'s `read:` key,
+  `auto-lint`/`lint-cmd` + `test-cmd` gating, and `.aiderignore` read blocks.
+  Aider has no skills/hooks mechanism, so those steps are skipped with an honest
+  note.
+
+## [0.8.0]
+
+### Changed
+
+- Commit guard is now scoped to the diff, and a verbose-comment check was added.
+
+## [0.7.1]
+
+### Changed
+
+- `plan` skill: refreshed the Phase 5 approval template.
+
+## [0.7.0]
+
+### Added
+
+- Full **Cline** backend support.
+
 ## [0.6.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ toolkit.init(repo=".", agents=["claude", "cursor"])
 
 ## 📋 Requirements
 - Python 3.10+
-- `klaussy-repo-conventions >= 1.4.0`
+- `klaussy-repo-conventions >= 1.5.0`
 - Claude Code CLI (optional, for `--init` enrichment)
 - `mcp` (optional, for MCP server support)
 
@@ -136,8 +136,7 @@ toolkit.init(repo=".", agents=["claude", "cursor"])
 
 ## 📜 Changelog
 
-### v0.9.0
-- **New backend: Aider (Ollama).** Model-agnostic, commonly run on a local Ollama model. Emits a flat `CONVENTIONS.md` (project-wide conventions + inlined path-scoped rules) wired into `.aider.conf.yml`'s `read:` key, `auto-lint`/`lint-cmd` + `test-cmd` gating, and `.aiderignore` read blocks. Aider has no skills/hooks mechanism, so those steps are skipped with an honest note.
+See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.10.0** (dependency gate hook, `adr-generator` + `security-audit` skills, shared cross-agent session state).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.9.0"
+version = "0.10.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, and Aider (Ollama)"
 readme = "README.md"
 license = "MIT"
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "typer>=0.9.0",
     "rich>=13.0.0",
-    "klaussy-repo-conventions>=1.4.0",
+    "klaussy-repo-conventions>=1.5.0",
 ]
 
 [project.urls]

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read

--- a/src/klaussy/agents/hooks.py
+++ b/src/klaussy/agents/hooks.py
@@ -30,6 +30,7 @@ console = Console()
 
 COMMIT_GUARD = "klaussy_commit_guard.py"
 COMMENT_GUARD = "klaussy_comment_guard.py"
+DEPENDENCY_GUARD = "klaussy_dependency_guard.py"
 READ_GUARD = "klaussy_read_guard.py"
 GUIDANCE_GUARD = "klaussy_plan_guidance.py"
 
@@ -139,6 +140,13 @@ def gemini_hooks(repo: Path, *, force: bool) -> None:
                    "command": f"{py} {hooks_dir}/{COMMENT_GUARD}",
                    "timeout": 60000}],
     })
+    _install_script(repo, f"{hooks_dir}/{DEPENDENCY_GUARD}", "dependency_guard.py")
+    before.append({
+        "matcher": "run_shell_command",
+        "hooks": [{"type": "command",
+                   "command": f"{py} {hooks_dir}/{DEPENDENCY_GUARD}",
+                   "timeout": 60000}],
+    })
     _install_script(repo, f"{hooks_dir}/{READ_GUARD}", "read_guard.py")
     read_cmd = {"type": "command", "command": f"{py} {hooks_dir}/{READ_GUARD}",
                 "timeout": 60000}
@@ -191,6 +199,11 @@ def cursor_hooks(repo: Path, *, force: bool) -> None:
         {"command": f"{hooks_dir}/{COMMENT_GUARD}", "type": "command",
          "failClosed": True}
     )
+    _install_script(repo, f"{hooks_dir}/{DEPENDENCY_GUARD}", "dependency_guard.py")
+    before_shell.append(
+        {"command": f"{hooks_dir}/{DEPENDENCY_GUARD}", "type": "command",
+         "failClosed": True}
+    )
     hooks["beforeShellExecution"] = before_shell
     _install_script(repo, f"{hooks_dir}/{READ_GUARD}", "read_guard.py")
     hooks["beforeReadFile"] = [
@@ -241,6 +254,10 @@ def codex_hooks(repo: Path, *, force: bool) -> None:
     bash_hooks.append({"type": "command",
                        "command": f"{py} {hooks_dir}/{COMMENT_GUARD}",
                        "timeout": 60})
+    _install_script(repo, f"{hooks_dir}/{DEPENDENCY_GUARD}", "dependency_guard.py")
+    bash_hooks.append({"type": "command",
+                       "command": f"{py} {hooks_dir}/{DEPENDENCY_GUARD}",
+                       "timeout": 60})
     hooks_cfg["PreToolUse"] = [{"matcher": "Bash", "hooks": bash_hooks}]
 
     if _write_json(repo / ".codex" / "hooks.json", {"hooks": hooks_cfg},
@@ -286,6 +303,13 @@ def copilot_hooks(repo: Path, *, force: bool) -> None:
         "type": "command",
         "bash": f"python3 {hooks_dir}/{COMMENT_GUARD}",
         "powershell": f"python {hooks_dir}/{COMMENT_GUARD}",
+        "timeoutSec": 60,
+    })
+    _install_script(repo, f"{hooks_dir}/{DEPENDENCY_GUARD}", "dependency_guard.py")
+    pre_tool.append({
+        "type": "command",
+        "bash": f"python3 {hooks_dir}/{DEPENDENCY_GUARD}",
+        "powershell": f"python {hooks_dir}/{DEPENDENCY_GUARD}",
         "timeoutSec": 60,
     })
     hooks_cfg["preToolUse"] = pre_tool
@@ -336,6 +360,9 @@ def antigravity_hooks(repo: Path, *, force: bool) -> None:
     _install_script(repo, f"{hooks_dir}/{COMMENT_GUARD}", "comment_guard.py")
     run_command_hooks.append({"type": "command",
                               "command": f"{py} {hooks_dir}/{COMMENT_GUARD}"})
+    _install_script(repo, f"{hooks_dir}/{DEPENDENCY_GUARD}", "dependency_guard.py")
+    run_command_hooks.append({"type": "command",
+                              "command": f"{py} {hooks_dir}/{DEPENDENCY_GUARD}"})
     pre.append({"matcher": "run_command", "hooks": run_command_hooks})
     config = {
         "klaussy": {
@@ -376,6 +403,7 @@ def cline_hooks(repo: Path, *, force: bool) -> None:
             format_cmd=fmt, lint_cmd=lint, comment_check_cmd=com,
         )
     _install_script(repo, f"{hooks_dir}/{COMMENT_GUARD}", "comment_guard.py")
+    _install_script(repo, f"{hooks_dir}/{DEPENDENCY_GUARD}", "dependency_guard.py")
     _install_script(repo, f"{hooks_dir}/{READ_GUARD}", "read_guard.py")
 
     # Install the bridge shim under PreToolUse and PostToolUse.

--- a/src/klaussy/agents/render.py
+++ b/src/klaussy/agents/render.py
@@ -81,7 +81,9 @@ def adapt_body(body: str, profile: CapabilityProfile) -> str:
         text = _DYNAMIC_BLOCK.sub(_replace_dynamic_block, text)
     if profile.skills_root != ".claude/skills":
         text = text.replace(".claude/skills/", f"{profile.skills_root}/")
-    return _capability_banner(body, profile) + text
+    # Detect capabilities against the adapted text: a subagent/plan-mode mention
+    # that lived inside a stripped ```! block shouldn't trigger a banner.
+    return _capability_banner(text, profile) + text
 
 
 def adapt_aux(content: str, profile: CapabilityProfile) -> str:

--- a/src/klaussy/gitignore.py
+++ b/src/klaussy/gitignore.py
@@ -11,6 +11,8 @@ GITIGNORE_ENTRIES = [
     "pr-description.md",
     "REVIEW_OUTPUT.md",
     "plan.md",
+    # Live cross-agent session state; the .agents/SESSION.md protocol doc stays committed.
+    ".agents/session.json",
 ]
 
 

--- a/src/klaussy/hooks.py
+++ b/src/klaussy/hooks.py
@@ -24,6 +24,10 @@ COMMENT_GUARD_SCRIPT_NAME = "comment_guard.py"
 COMMENT_GUARD_RELPATH = f".claude/hooks/{COMMENT_GUARD_SCRIPT_NAME}"
 COMMENT_GUARD_COMMAND = f"python3 {COMMENT_GUARD_RELPATH}"
 
+DEPENDENCY_GUARD_SCRIPT_NAME = "dependency_guard.py"
+DEPENDENCY_GUARD_RELPATH = f".claude/hooks/{DEPENDENCY_GUARD_SCRIPT_NAME}"
+DEPENDENCY_GUARD_COMMAND = f"python3 {DEPENDENCY_GUARD_RELPATH}"
+
 PLAN_GUIDANCE_SCRIPT_NAME = "plan_guidance.py"
 PLAN_GUIDANCE_RELPATH = f".claude/hooks/{PLAN_GUIDANCE_SCRIPT_NAME}"
 PLAN_GUIDANCE_COMMAND = f"python3 {PLAN_GUIDANCE_RELPATH}"
@@ -128,6 +132,23 @@ def _install_comment_guard_script(repo: Path) -> Path:
     dest.parent.mkdir(parents=True, exist_ok=True)
     source = resources.files("klaussy").joinpath(
         f"templates/hooks/{COMMENT_GUARD_SCRIPT_NAME}"
+    )
+    dest.write_text(source.read_text())
+    mode = dest.stat().st_mode
+    dest.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return dest
+
+
+def _install_dependency_guard_script(repo: Path) -> Path:
+    """Copy the dependency gate into .claude/hooks/ and mark executable.
+
+    No commands are baked in — it inspects the install command and blocks on a
+    new-dependency add, so the cross-agent `multi/` copy is used verbatim (it
+    already reads Claude's `tool_input.command` payload shape)."""
+    dest = repo / DEPENDENCY_GUARD_RELPATH
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    source = resources.files("klaussy").joinpath(
+        f"templates/hooks/multi/{DEPENDENCY_GUARD_SCRIPT_NAME}"
     )
     dest.write_text(source.read_text())
     mode = dest.stat().st_mode
@@ -259,6 +280,10 @@ def scaffold_hooks(*, repo: Path, force: bool = False) -> Path:
     # Comment guard rewrites an outgoing `gh` comment through `klaussy humanize`
     # (PreToolUse updatedInput). No project-specific command, so always installed.
     _install_comment_guard_script(repo)
+    # Dependency gate blocks a `pip/npm/poetry/… install <pkg>` that adds a new
+    # named dependency until the agent confirms it. No project-specific command,
+    # so always installed.
+    _install_dependency_guard_script(repo)
     def _entry(matcher: str, command: str) -> dict:
         return {"matcher": matcher, "hooks": [{"type": "command", "command": command}]}
 
@@ -266,6 +291,7 @@ def scaffold_hooks(*, repo: Path, force: bool = False) -> Path:
         _entry("Read", GUARD_COMMAND),
         _entry("EnterPlanMode", PLAN_GUIDANCE_COMMAND),
         _entry("Bash", COMMENT_GUARD_COMMAND),
+        _entry("Bash", DEPENDENCY_GUARD_COMMAND),
     ]
     desired_post: list[dict] = [_entry("WebFetch", GUARD_COMMAND)]
 
@@ -307,6 +333,9 @@ def scaffold_hooks(*, repo: Path, force: bool = False) -> Path:
     console.print(f"[green]✔ Installed read-injection guard at {GUARD_RELPATH}[/green]")
     console.print(
         f"[green]✔ Installed pre-plan guidance hook at {PLAN_GUIDANCE_RELPATH}[/green]"
+    )
+    console.print(
+        f"[green]✔ Installed dependency gate at {DEPENDENCY_GUARD_RELPATH}[/green]"
     )
     if has_commit_guard:
         console.print(

--- a/src/klaussy/session.py
+++ b/src/klaussy/session.py
@@ -1,0 +1,130 @@
+"""Scaffold a cross-agent shared session-state file.
+
+A task often changes hands mid-flight: a CLI agent makes a quick edit, an IDE
+agent takes over the heavy browsing, a third runs the tests. Each one
+rediscovers the active branch, the current task, and the failures the last one
+already hit. `.agents/session.json` is a small, tool-neutral handoff note any
+agent can read at the start of a session and update when the working state
+changes — the "shared brain" that keeps Claude Code, Cursor, Cline, and the rest
+on the same page.
+
+`.agents/` is already klaussy's cross-tool neutral directory (Codex and Cline
+read their skills from `.agents/skills`), so the shared session file belongs
+there by convention rather than in a tool-specific location.
+
+It holds *live working state* for one checkout (possibly several tools at once),
+so it's gitignored rather than committed — `update_gitignore` adds the entry. The
+protocol doc beside it (`.agents/SESSION.md`) IS committed: it documents the
+format so every agent on the repo reads and writes the file the same way.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from rich.console import Console
+
+console = Console()
+
+SESSION_RELPATH = ".agents/session.json"
+PROTOCOL_RELPATH = ".agents/SESSION.md"
+
+# Bumped if the JSON shape changes so an agent can detect an older file.
+SCHEMA_VERSION = 1
+
+
+def _current_branch(repo: Path) -> str:
+    """The repo's current git branch, or "" when it can't be determined."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo),
+        )
+    except OSError:
+        return ""
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+def _skeleton(repo: Path) -> dict:
+    """An empty session record for a fresh checkout."""
+    return {
+        "schema": SCHEMA_VERSION,
+        "updated": None,  # ISO-8601 timestamp; set by whichever agent writes
+        "branch": _current_branch(repo),
+        "task": None,  # one-line description of what's being worked on
+        "plan": [],  # [{"step": str, "status": "pending|in_progress|done"}]
+        "known_failures": [],  # failing tests / reproductions seen this session
+        "notes": None,  # free-form handoff context for the next agent
+    }
+
+
+_PROTOCOL_DOC = """\
+# Shared agent session state
+
+`session.json` in this directory is a tool-neutral handoff note for whichever AI
+coding agent is working in this checkout (Claude Code, Cursor, Cline, Gemini,
+Codex, Copilot, Antigravity, …). It carries the live working state so an agent
+picking up the task doesn't have to rediscover it.
+
+It is **local working state, not source** — it's gitignored. Don't commit it.
+This README is committed so every agent reads and writes the file the same way.
+
+## Contract
+
+At the **start** of a session, read `session.json`. If `task`/`plan`/
+`known_failures` are populated, continue that work instead of starting cold.
+
+When the working state changes, **update** the file:
+
+- switching to a different task → set `task` and reset `plan`
+- finishing or starting a plan step → update that step's `status`
+- hitting a failing test or a reproduction → append it to `known_failures`;
+  remove it once fixed
+- moving to a different branch → set `branch`
+- always set `updated` to the current ISO-8601 timestamp when you write
+
+Keep it small — a handoff note, not a log. If it's stale or irrelevant to the
+current request, reset it rather than reasoning from it.
+
+## Schema (`schema: 1`)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schema` | int | Format version; reset the file if you don't recognize it. |
+| `updated` | string \\| null | ISO-8601 timestamp of the last write. |
+| `branch` | string | Active git branch. |
+| `task` | string \\| null | One-line description of the current task. |
+| `plan` | array | `{ "step": string, "status": "pending" \\| "in_progress" \\| "done" }`. |
+| `known_failures` | array | Failing tests or reproductions seen this session. |
+| `notes` | string \\| null | Free-form context for the next agent. |
+"""
+
+
+def scaffold_session(*, repo: Path, force: bool = False) -> Path:
+    """Write the shared session-state file and its protocol doc.
+
+    The protocol doc is a generated artifact — always (re)written so it stays
+    current. `session.json` holds live state, so it's only created when absent
+    (or `force`), never clobbered out from under an agent mid-task.
+    """
+    repo = repo.resolve()
+    agents_dir = repo / ".agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+
+    protocol = repo / PROTOCOL_RELPATH
+    protocol.write_text(_PROTOCOL_DOC)
+
+    session = repo / SESSION_RELPATH
+    if session.exists() and not force:
+        console.print(
+            f"[dim]{SESSION_RELPATH} exists; leaving live state untouched.[/dim]"
+        )
+    else:
+        session.write_text(json.dumps(_skeleton(repo), indent=2) + "\n")
+        console.print(f"[green]✔ Scaffolded shared session state at {SESSION_RELPATH}[/green]")
+
+    return session

--- a/src/klaussy/skills.py
+++ b/src/klaussy/skills.py
@@ -24,6 +24,8 @@ SKILL_NAMES = [
     "explain",
     "humanize",
     "new-worktree",
+    "adr-generator",
+    "security-audit",
 ]
 
 VERSION_FILE = ".klaussy-version"

--- a/src/klaussy/templates/hooks/multi/cline_tool_guard.py
+++ b/src/klaussy/templates/hooks/multi/cline_tool_guard.py
@@ -17,6 +17,7 @@ from pathlib import Path
 HOOKS_DIR = Path(__file__).resolve().parent
 COMMIT_GUARD = HOOKS_DIR / "klaussy_commit_guard.py"
 COMMENT_GUARD = HOOKS_DIR / "klaussy_comment_guard.py"
+DEPENDENCY_GUARD = HOOKS_DIR / "klaussy_dependency_guard.py"
 READ_GUARD = HOOKS_DIR / "klaussy_read_guard.py"
 
 # web_fetch is the confirmed VS Code name; the others cover runtime drift.
@@ -65,7 +66,7 @@ def _handle_pre(payload: dict) -> None:
     if isinstance(command, str) and command:
         # Gate commands via commit and comment guards.
         synthesized = {"tool_input": {"command": command}}
-        for guard in (COMMIT_GUARD, COMMENT_GUARD):
+        for guard in (COMMIT_GUARD, COMMENT_GUARD, DEPENDENCY_GUARD):
             rc, err = _run_guard(guard, synthesized)
             if rc == 2:
                 _block(err or "Blocked by klaussy guard.")

--- a/src/klaussy/templates/hooks/multi/dependency_guard.py
+++ b/src/klaussy/templates/hooks/multi/dependency_guard.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Cross-agent pre-shell guard: a speed bump before adding a new dependency.
+
+Installed by klaussy into a target agent's hooks directory and wired to that
+agent's "before shell/tool" event (Gemini BeforeTool, Cursor
+beforeShellExecution, Codex PreToolUse, Copilot preToolUse, Antigravity
+run_command, Cline PreToolUse). Agents reach for a new package readily — a whole
+HTTP client for one request, lodash for a one-line helper, a second library that
+duplicates one already vendored. The guard catches package-manager commands that
+ADD a *new named* dependency (`pip install requests`, `npm install lodash`,
+`poetry add x`, `cargo add y`, …) and blocks once, asking the agent to confirm
+the dep is actually needed and not coverable by the stdlib or an existing dep.
+
+It deliberately does NOT fire on commands that merely sync an existing manifest
+(`npm install` / `npm ci`, `pip install -r requirements.txt`, `pip install -e .`,
+`poetry install`, `uv sync`, a bare `yarn`) — those add nothing new.
+
+Like the other cross-agent guards, these protocols can't surface a soft warning,
+so the mechanism is a block (exit 2 + stderr, honored by every supported agent).
+To proceed once confirmed, the agent re-runs the command prefixed with
+`KLAUSSY_DEPS_OK=1` — a stateless, self-documenting bypass the guard detects in
+the command string itself.
+
+Hardened to never crash: any unexpected payload or error exits 0 (allow), since
+some agents (e.g. Copilot preToolUse) treat a crashing hook as a deny of every
+tool call. Pure stdlib so the repo stays portable.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+
+# Prefix the agent adds to a confirmed install to wave it through. Detected as a
+# substring of the command, so it survives the stateless per-call hook model.
+BYPASS_PREFIX = "KLAUSSY_DEPS_OK=1"
+
+# (manager, verb) pairs whose positional arguments are *new* named dependencies.
+# Bare forms with no positional (e.g. `npm install`, `pnpm i`) add nothing and
+# fall through to allow — see _packages_after.
+_ADDERS = {
+    ("npm", "install"),
+    ("npm", "i"),
+    ("npm", "add"),
+    ("pnpm", "install"),
+    ("pnpm", "i"),
+    ("pnpm", "add"),
+    ("yarn", "add"),
+    ("bun", "add"),
+    ("pip", "install"),
+    ("pip3", "install"),
+    ("uv", "add"),
+    ("poetry", "add"),
+    ("cargo", "add"),
+    ("gem", "install"),
+    ("go", "get"),
+}
+
+# Flags that consume the following token as a path/target, not a new named dep
+# (`pip install -r reqs.txt`, `pip install -e .`, `-c constraints.txt`).
+_FLAGS_WITH_VALUE = {"-r", "--requirement", "-c", "--constraint", "-e", "--editable"}
+
+
+def _extract_command(payload: dict) -> str:
+    """Pull the shell command string out of any supported agent's payload."""
+    for container_key in ("tool_input", "toolArgs", "input"):
+        container = payload.get(container_key)
+        if isinstance(container, dict):
+            value = container.get("command")
+            if isinstance(value, str) and value:
+                return value
+        elif isinstance(container, str) and container:
+            return container
+    top = payload.get("command")
+    if isinstance(top, str):
+        return top
+    return ""
+
+
+def _packages_after(args: list[str]) -> list[str]:
+    """Positional package names among a verb's arguments (flags/paths excluded)."""
+    pkgs: list[str] = []
+    skip_next = False
+    for tok in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in _FLAGS_WITH_VALUE:
+            skip_next = True
+            continue
+        if tok.startswith("-"):
+            continue
+        # Current project / requirement or lock files / local paths — not a new
+        # named dependency, just a sync of what's already declared.
+        if tok == "." or tok.endswith((".txt", ".cfg", ".toml")):
+            continue
+        if tok.startswith(("./", "../", "/")):
+            continue
+        pkgs.append(tok)
+    return pkgs
+
+
+def _added_packages(command: str) -> list[str]:
+    """New named dependencies an install command would add; [] if it adds none."""
+    if BYPASS_PREFIX in command:
+        return []
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return []
+    for i in range(len(tokens) - 1):
+        mgr, verb = tokens[i], tokens[i + 1]
+        # `uv pip install <pkg>` mirrors pip's argument shape.
+        if mgr == "uv" and verb == "pip" and i + 2 < len(tokens) and tokens[i + 2] == "install":
+            return _packages_after(tokens[i + 3 :])
+        if (mgr, verb) in _ADDERS:
+            return _packages_after(tokens[i + 2 :])
+    return []
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        if not isinstance(payload, dict):
+            return 0
+        command = _extract_command(payload)
+        packages = _added_packages(command)
+        if not packages:
+            return 0
+        names = ", ".join(packages)
+        print(
+            f"klaussy dependency gate: this command adds a new dependency ({names}). "
+            "Confirm it's actually needed and can't be covered by the standard "
+            "library or a package already in the manifest. If it is needed, re-run "
+            f"the command prefixed with `{BYPASS_PREFIX}` to proceed, e.g.:\n"
+            f"  {BYPASS_PREFIX} {command}",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:  # never crash — see module docstring
+        print(f"klaussy dependency gate error (allowing): {exc}", file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/klaussy/templates/skills/adr-generator/SKILL.md
+++ b/src/klaussy/templates/skills/adr-generator/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: {{REPO}}-adr-generator
+description: Use when the user wants to record an architectural decision — drafting an Architecture Decision Record (ADR) or RFC, documenting a design choice and its trade-offs, or capturing why an approach was taken. Detects the repo's existing ADR location and template style (MADR or Nygard) and matches it; if none exists, sets one up. Writes the record; it does not change code.
+allowed-tools: Read Grep Glob Bash(git log *) Write
+---
+
+You are drafting an Architecture Decision Record. An ADR captures one decision: the context that forced it, the choice made, and the consequences accepted. Follow these phases.
+
+---
+
+## Phase 1: Find the existing convention
+
+Before writing anything, learn how this repo already records decisions so the new one matches.
+
+- Look for an ADR directory: `docs/adr/`, `docs/decisions/`, `docs/architecture/decisions/`, `adr/`, or `rfcs/`. Use Glob/Grep.
+- If records exist, read the two most recent. Match their template (MADR vs Nygard), heading style, status vocabulary, and filename scheme (`NNNN-title.md` is the common one).
+- Determine the next sequence number from the highest existing file.
+- If no ADR directory exists, default to `docs/adr/` with the MADR template below and start at `0001`. Tell the user you're establishing the convention.
+
+Do not invent a second competing format when one is already in use.
+
+## Phase 2: Gather the decision
+
+You need enough to write each section truthfully. If the user's request already supplies it, don't re-ask — proceed. Otherwise ask only for what's missing:
+
+- **Title** — the decision in a short noun phrase ("Use Postgres for the event store").
+- **Context** — the forces in play: the problem, constraints, and what made a decision necessary now.
+- **Options considered** — the alternatives and why each was or wasn't chosen.
+- **Decision** — the option taken.
+- **Consequences** — what this makes easier, what it makes harder, and any follow-up work or risk accepted.
+
+Ground the context in the codebase where you can: cite the modules, dependencies, or `git log` history that motivated the decision rather than writing in the abstract.
+
+## Phase 3: Write the record
+
+Use the repo's established template if you found one. Otherwise use this MADR-style skeleton:
+
+```markdown
+# NNNN. <title>
+
+- Status: proposed
+- Date: <YYYY-MM-DD>
+- Deciders: <who>
+
+## Context and problem statement
+
+<the forces and the problem, in a few sentences>
+
+## Considered options
+
+- <option 1>
+- <option 2>
+
+## Decision outcome
+
+Chosen: **<option>**, because <justification>.
+
+### Consequences
+
+- Good: <what improves>
+- Bad: <what we accept or take on>
+
+## More information
+
+<links to related ADRs, issues, or discussion>
+```
+
+Set status to `proposed` unless the user says the decision is already accepted. Write the file to the directory and filename scheme from Phase 1. Report the path back to the user and offer to mark it `accepted` once they confirm.
+
+{{HUMANIZE}}

--- a/src/klaussy/templates/skills/security-audit/SKILL.md
+++ b/src/klaussy/templates/skills/security-audit/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: {{REPO}}-security-audit
+description: Use when the user wants a focused security pass over the current change — scanning the branch diff for leaked secrets, injection and SSRF, broken access control, unsafe deserialization, and newly added or vulnerable dependencies. Narrower and deeper than the general review skill: it applies only the security lenses and reports findings; it does not refactor or fix.
+allowed-tools: Read Grep Glob Bash(git diff *) Bash(git log *)
+---
+
+You are running a security audit of the current change. Scope is the diff against the base branch and the immediate context of what it touches — not the whole tree, and not style or architecture. Report findings only; do not edit code.
+
+If `{{BASE_BRANCH}}` is missing or unset, default to `dev` if it exists, otherwise `main`. Read the change with `git diff {{BASE_BRANCH}}...HEAD` first.
+
+## Lenses
+
+Apply each lens to the ADDED and changed lines. A finding must point to a concrete line, not a general worry.
+
+**1. Secrets & credentials** (Severity: High)
+- API keys, tokens, passwords, private keys, connection strings with embedded credentials, or high-entropy literals that look like real secrets in added lines. Obvious placeholders (`YOUR_API_KEY`, `xxx`, `changeme`) are not findings.
+
+**2. Injection & untrusted input** (Severity: High)
+- SQL/NoSQL built by string concatenation or f-strings from request input instead of parameterized queries.
+- Shell execution from untrusted input (`shell=True`, string-built commands, `eval`/`exec`).
+- Command, path-traversal, template, or header injection where user input reaches a sink unsanitized.
+
+**3. SSRF & outbound requests** (Severity: High)
+- A request URL, host, or port derived from user input without an allowlist — especially fetches that could reach internal addresses or metadata endpoints.
+
+**4. Access control & authn/authz** (Severity: High)
+- A new endpoint, handler, or operation that skips the auth/permission check its peers apply.
+- Authorization decided on client-supplied data (role/owner from the request body), missing object-level ownership checks (IDOR), or a check that's logged but not enforced.
+
+**5. Unsafe deserialization & data handling** (Severity: High)
+- `pickle`, `yaml.load` (non-safe), `eval`-based parsing, or native deserialization of untrusted bytes.
+- Disabled TLS verification (`verify=False`), weak crypto/hashing for security purposes (MD5/SHA1 for passwords, hardcoded IVs).
+
+**6. Dependencies** (Severity: Medium unless a known CVE → High)
+- New dependencies added in this diff (manifest or lockfile). For each, ask: is it necessary, maintained, and from a trusted source? Flag typosquat-looking names and duplicates of a library already vendored.
+- Pinned-to-vulnerable or wildcard version ranges introduced by the change.
+
+## Output
+
+For each finding: `file:line`, the lens, a one-line description of the exploit path, and the minimal fix. Order by severity. If a lens is clean, say so in one line rather than padding. If the diff has no security-relevant surface, state that plainly.
+
+Out of scope: naming, formatting, performance, test coverage, and anything outside the diff. Do not propose refactors and do not edit files — this is a read-only audit.
+
+{{HUMANIZE}}

--- a/src/klaussy/toolkit.py
+++ b/src/klaussy/toolkit.py
@@ -24,6 +24,7 @@ from klaussy.claude_md import run_init
 from klaussy.github import scaffold_github
 from klaussy.gitignore import update_gitignore
 from klaussy.humanize import humanize as _humanize_text
+from klaussy.session import scaffold_session
 from klaussy.skills import SKILL_NAMES
 
 __all__ = [
@@ -36,6 +37,7 @@ __all__ = [
     "hooks",
     "github",
     "checklist",
+    "session",
     "humanize",
     "humanize_files",
     "status",
@@ -137,6 +139,7 @@ def init(
             )
         )
     steps.append(("PR template", lambda: scaffold_github(repo=repo, force=force)))
+    steps.append(("shared session", lambda: scaffold_session(repo=repo, force=force)))
     steps.append((".gitignore", lambda: update_gitignore(repo=repo)))
     return _run_steps(repo, selected, steps)
 
@@ -195,6 +198,14 @@ def hooks(
 def github(repo: PathLike = ".", *, force: bool = False) -> Path | None:
     """Generate the PR template; returns its path, or None if one already exists."""
     return scaffold_github(repo=Path(repo).resolve(), force=force)
+
+
+def session(repo: PathLike = ".", *, force: bool = False) -> Path:
+    """Scaffold the cross-agent shared session-state file; returns its path.
+
+    Writes `.agents/session.json` (live working state, gitignored) and its
+    protocol doc. Existing live state is preserved unless `force` is set."""
+    return scaffold_session(repo=Path(repo).resolve(), force=force)
 
 
 def checklist(

--- a/tests/test_dependency_guard.py
+++ b/tests/test_dependency_guard.py
@@ -1,0 +1,114 @@
+"""Tests for the cross-agent dependency gate (new-dependency speed bump)."""
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from klaussy import hooks as hooks_mod
+
+TEMPLATES = Path(hooks_mod.__file__).parent / "templates" / "hooks"
+
+
+def _load(relpath: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, TEMPLATES / relpath)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def guard():
+    return _load("multi/dependency_guard.py", "_dependency_guard")
+
+
+# Commands that ADD a new named dependency → the package list the guard reports.
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("npm install lodash", ["lodash"]),
+        ("npm i lodash react", ["lodash", "react"]),
+        ("npm add lodash", ["lodash"]),
+        ("pnpm add zod", ["zod"]),
+        ("yarn add react", ["react"]),
+        ("bun add hono", ["hono"]),
+        ("pip install requests", ["requests"]),
+        ("pip3 install flask", ["flask"]),
+        ("python -m pip install flask", ["flask"]),
+        ("uv add pydantic", ["pydantic"]),
+        ("uv pip install rich", ["rich"]),
+        ("poetry add httpx", ["httpx"]),
+        ("cargo add serde", ["serde"]),
+        ("gem install rails", ["rails"]),
+        ("go get github.com/foo/bar", ["github.com/foo/bar"]),
+        ("pip install --upgrade requests", ["requests"]),
+    ],
+)
+def test_detects_new_dependency(guard, command, expected):
+    assert guard._added_packages(command) == expected
+
+
+# Commands that only sync an existing manifest → nothing added.
+@pytest.mark.parametrize(
+    "command",
+    [
+        "npm install",
+        "npm ci",
+        "pnpm install",
+        "yarn",
+        "yarn install",
+        "pip install -r requirements.txt",
+        "pip install -e .",
+        "pip install .",
+        "poetry install",
+        "uv sync",
+        "echo hello",
+        "git commit -m wip",
+    ],
+)
+def test_ignores_manifest_sync(guard, command):
+    assert guard._added_packages(command) == []
+
+
+def test_bypass_token_allows(guard):
+    assert guard._added_packages("KLAUSSY_DEPS_OK=1 pip install requests") == []
+
+
+def _run(guard, payload, monkeypatch) -> tuple[int, str]:
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    err = io.StringIO()
+    monkeypatch.setattr("sys.stderr", err)
+    return guard.main(), err.getvalue()
+
+
+def test_main_blocks_new_dependency(guard, monkeypatch):
+    rc, err = _run(guard, {"tool_input": {"command": "pip install requests"}}, monkeypatch)
+    assert rc == 2
+    assert "requests" in err
+    assert "KLAUSSY_DEPS_OK=1" in err
+
+
+def test_main_allows_manifest_sync(guard, monkeypatch):
+    rc, err = _run(guard, {"tool_input": {"command": "npm install"}}, monkeypatch)
+    assert rc == 0
+    assert err == ""
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"toolArgs": {"command": "pip install requests"}},  # Copilot CLI shape
+        {"command": "pip install requests"},  # Cursor top-level shape
+    ],
+)
+def test_main_reads_each_agent_payload_shape(guard, payload, monkeypatch):
+    rc, _ = _run(guard, payload, monkeypatch)
+    assert rc == 2
+
+
+def test_main_never_crashes_on_garbage(guard, monkeypatch):
+    rc, _ = _run(guard, ["not", "a", "dict"], monkeypatch)
+    assert rc == 0

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,79 @@
+"""Tests for the cross-agent shared session-state scaffolder."""
+
+import json
+import subprocess
+from pathlib import Path
+
+from klaussy import toolkit
+from klaussy.gitignore import GITIGNORE_ENTRIES, update_gitignore
+from klaussy.session import (
+    PROTOCOL_RELPATH,
+    SCHEMA_VERSION,
+    SESSION_RELPATH,
+    scaffold_session,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(repo), check=True, capture_output=True)
+
+
+def test_scaffolds_session_and_protocol(tmp_path: Path):
+    scaffold_session(repo=tmp_path)
+    session = tmp_path / SESSION_RELPATH
+    protocol = tmp_path / PROTOCOL_RELPATH
+    assert session.exists() and protocol.exists()
+
+    data = json.loads(session.read_text())
+    assert data["schema"] == SCHEMA_VERSION
+    assert data["plan"] == [] and data["known_failures"] == []
+    assert data["task"] is None
+    assert "Shared agent session state" in protocol.read_text()
+
+
+def test_records_current_branch(tmp_path: Path):
+    _git(tmp_path, "init")
+    _git(tmp_path, "commit", "--allow-empty", "-m", "init")
+    _git(tmp_path, "checkout", "-b", "feature/x")
+    scaffold_session(repo=tmp_path)
+    data = json.loads((tmp_path / SESSION_RELPATH).read_text())
+    assert data["branch"] == "feature/x"
+
+
+def test_live_state_preserved_without_force(tmp_path: Path):
+    scaffold_session(repo=tmp_path)
+    session = tmp_path / SESSION_RELPATH
+    session.write_text(json.dumps({"schema": 1, "task": "in progress"}) + "\n")
+
+    scaffold_session(repo=tmp_path)  # second run, no force
+    assert json.loads(session.read_text())["task"] == "in progress"
+
+
+def test_force_overwrites_live_state(tmp_path: Path):
+    scaffold_session(repo=tmp_path)
+    session = tmp_path / SESSION_RELPATH
+    session.write_text(json.dumps({"schema": 1, "task": "stale"}) + "\n")
+
+    scaffold_session(repo=tmp_path, force=True)
+    assert json.loads(session.read_text())["task"] is None
+
+
+def test_protocol_always_rewritten(tmp_path: Path):
+    scaffold_session(repo=tmp_path)
+    protocol = tmp_path / PROTOCOL_RELPATH
+    protocol.write_text("clobbered")
+    scaffold_session(repo=tmp_path)  # no force
+    assert "Shared agent session state" in protocol.read_text()
+
+
+def test_session_file_is_gitignored_but_not_protocol(tmp_path: Path):
+    update_gitignore(repo=tmp_path)
+    content = (tmp_path / ".gitignore").read_text()
+    assert SESSION_RELPATH in content
+    assert PROTOCOL_RELPATH not in GITIGNORE_ENTRIES
+
+
+def test_toolkit_session_public_surface(tmp_path: Path):
+    path = toolkit.session(tmp_path)
+    assert path == (tmp_path / SESSION_RELPATH).resolve()
+    assert path.exists()


### PR DESCRIPTION
## Summary

Implements the actionable recommendations from the architecture analysis. Three net-new features plus a small fix, released as v0.10.0.

The analysis's short-term items were handled up front: the banner-detection bug was real and is fixed; the "strict spaces in allowed-tools" item was already satisfied (no change); and mapping Antigravity allowed-tools was **deliberately skipped** — it would silently drop `Bash(...)` scoping and weaken security versus the current documented fall-back.

## Changes

- **Dependency gate hook** (`templates/hooks/multi/dependency_guard.py`): blocks package-manager commands that add a *new named* dependency (`pip install requests`, `npm install lodash`, `poetry add`, `cargo add`, `go get`, …). Bare manifest syncs (`npm install`, `pip install -r requirements.txt`, `uv sync`) pass through. Confirm a needed dep by prefixing `KLAUSSY_DEPS_OK=1`. Wired into all seven agents with a pre-shell hook (Claude, Gemini, Cursor, Codex, Copilot, Antigravity, Cline).
- **Two new skills**: `adr-generator` (drafts ADRs, matching the repo's existing location/template or establishing one) and `security-audit` (focused diff-scoped pass: secrets, injection, SSRF, access control, unsafe deserialization, new/vulnerable deps). Added to the canonical `SKILL_NAMES` (now 15); `toolkit.py`/`mcp_server.py` consume it dynamically.
- **Shared session state**: `init` scaffolds `.agents/session.json` (live working state — branch, task, plan, known failures) plus the committed `.agents/SESSION.md` protocol doc. Lives in `.agents/`, klaussy's existing cross-tool neutral dir. Live state is gitignored; exposed as `toolkit.session()`.
- **Fix**: capability banner is detected against the *adapted* skill body, so a sub-agent/plan-mode mention inside a stripped dynamic-shell block no longer triggers a spurious banner.
- Bumps `klaussy-repo-conventions` requirement to `>=1.5.0` (pre-existing working-tree change, release-aligned) and version to v0.10.0 with a changelog entry.

## Test Plan

- New: `tests/test_dependency_guard.py` (16 cases — detection across 10 package managers, manifest-sync allow-list, bypass token, payload shapes, crash-safety) and `tests/test_session.py` (7 cases — scaffold, branch capture, live-state preservation, force overwrite, gitignore).
- Full suite: **297 passed, 13 skipped** (was 256).
- `ruff check src/ tests/` clean (the CI-enforced lint).
- End-to-end `init` smoke test confirmed all three features land together across claude/cursor/cline.

## Checklist

- [x] Tests added and passing
- [x] Lint (`ruff check`) clean
- [x] Changelog + version bumped
- [x] No unrelated files committed (analysis artifact left untracked)