### PR TITLE
test(evals): add security-audit prompt eval

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks configuration for klaussy-agents.
+#
+# Keeps the full default ruleset (useDefault) and adds one narrowly-scoped
+# allowlist: the security-audit eval fixture deliberately embeds a realistic
+# fake secret so the skill has something real to flag — an obvious placeholder
+# wouldn't trigger the audit (the skill ignores "YOUR_API_KEY"-style stubs by
+# design). The allowlist is scoped to that single fixture file so a real secret
+# committed anywhere else still fails the scan.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional fake secret in the security-audit eval fixture"
+paths = [
+  '''tests/evals/test_security_audit_eval\.py''',
+]

--- a/tests/evals/test_security_audit_eval.py
+++ b/tests/evals/test_security_audit_eval.py
@@ -1,0 +1,54 @@
+"""Eval: the security-audit skill catches planted vulnerabilities and stays civil.
+
+The diff has two real, distinct security defects — a hardcoded database
+password (secrets lens) and a SQL injection via f-string (injection lens). A
+useful audit must flag both, and must not turn into insults. Like the review
+eval, this is a precision-on-known-bad check, scoped to the security lenses.
+
+The planted credential is a plain password rather than a provider token (e.g. a
+Stripe/AWS key) on purpose: a recognizable provider token trips git-layer secret
+scanners on push, while a bare password is just as clearly a hardcoded
+credential to the audit skill without matching a partner pattern.
+"""
+
+from __future__ import annotations
+
+import harness
+
+# Planted: a hardcoded DB password used in connect() AND an f-string-built SQL
+# query (injection).
+DIFF_WITH_VULNS = """\
+diff --git a/src/billing.py b/src/billing.py
+@@
++DB_PASSWORD = "Pg7xQ2-billing-prod-9f3a"
++
++def charge_account(account_id, amount):
++    conn = db.connect(host="10.0.0.5", user="billing", password=DB_PASSWORD)
++    row = conn.execute(
++        f"SELECT balance FROM accounts WHERE id = {account_id}"
++    ).fetchone()
++    return row
+"""
+
+INSULTS = ["stupid", "idiot", "garbage", "trash", "moron", "dumb"]
+
+
+@harness.requires_eval_env
+def test_audit_flags_secret_and_injection_and_stays_civil():
+    out = harness.run_skill(
+        "security-audit",
+        DIFF_WITH_VULNS,
+        instruction="Audit this diff. It is the entire change under review.",
+        max_tokens=1500,
+    )
+    low = out.lower()
+
+    assert any(k in low for k in ("secret", "credential", "password", "hardcod")), (
+        f"audit missed the hardcoded credential: {out!r}"
+    )
+    assert any(k in low for k in ("sql", "injection", "parameter", "sanitiz", "f-string")), (
+        f"audit missed the SQL injection: {out!r}"
+    )
+
+    found_insults = [w for w in INSULTS if w in low]
+    assert not found_insults, f"audit used insults {found_insults}: {out!r}"


### PR DESCRIPTION
## Summary

Adds a prompt eval for the `security-audit` skill (shipped in v0.10.0 without eval coverage), so every eval-able content skill now has one.

## Changes

- **`tests/evals/test_security_audit_eval.py`** — a planted-vulnerability precision check modeled on the `review` eval. The fixture diff has two distinct defects: a **hardcoded DB password** (secrets lens) and an **f-string-built SQL query** (injection lens). Asserts the audit flags **both** and **stays civil**. Opt-in; skipped in normal CI (gated on `KLAUSSY_RUN_EVALS=1` + the `claude` CLI).
- **`.gitleaks.toml`** — the fixture uses a realistic credential on purpose (the skill ignores obvious placeholders like `YOUR_API_KEY`, so a stub wouldn't exercise the secrets lens). `useDefault = true` keeps the full default ruleset; the allowlist is scoped to that single fixture file, so a real secret committed anywhere else still fails the scan.

## Note on the credential choice

The planted secret is a **plain DB password, not a provider token** (Stripe/AWS/etc.) by design. A recognizable provider key trips GitHub's git-layer push protection (it blocked an earlier revision of this branch), while a bare password is just as clearly a hardcoded credential to the audit skill without matching a partner pattern.

## Test Plan

- `pytest tests/` — **297 passed, 14 skipped** (the new eval is the +1 skip).
- **Live-validated** with `KLAUSSY_RUN_EVALS=1` against a real model: the skill flagged both the hardcoded password and the injection and stayed civil (passed, ~16s).
- `ruff check src/ tests/` clean.
- gitleaks verified locally: working tree clean with the config; a control secret placed in any other file is still caught (allowlist scoped correctly, defaults intact); git-mode scan of the branch (what CI runs) reports no leaks.

## Checklist

- [x] Eval added and live-validated
- [x] gitleaks config scoped so it can't mask real secrets elsewhere
- [x] No provider tokens in fixtures (push-protection safe)
- [x] Lint passing