### PR TITLE
feat(review): trim diffs with review-prep, wire into review skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
 ### Added
 
+- **`klaussy review-prep` + faster review skill** — a deterministic diff
+  pre-processor that trims a branch diff to the reviewable files (dropping
+  lockfiles, generated/vendored trees, minified/binary blobs, and pure renames)
+  and emits an explicit manifest of what it excluded. The `review` skill's
+  Phase 1 now sources its diff from `review-prep` (falling back to `git diff`
+  when the CLI isn't on PATH) and triages on the trimmed line count, so the
+  model reads far fewer tokens on noisy PRs. On a representative diff this cut
+  the input from 631 to 11 lines (~98%).
 - **`slop-coded` skill** — the joke inverse of `humanize`. Takes clean human
   prose and inflates it into maximal AI slop (em-dashes, filler openers, the
   "it's not X — it's Y" reframe, "and that's the whole point", emoji bullets,

--- a/src/klaussy/cli.py
+++ b/src/klaussy/cli.py
@@ -16,6 +16,7 @@ from klaussy.comment_lint import analyze as analyze_comments
 from klaussy.github import scaffold_github
 from klaussy.gitignore import update_gitignore
 from klaussy.humanize import humanize as humanize_text
+from klaussy.review_prep import prepare_review, render_dict, render_markdown
 
 app = typer.Typer(name="klaussy", help="Multi-agent repo boilerplate generator.")
 console = Console()
@@ -310,6 +311,32 @@ def comment_lint(
         console.print(finding.render())
     if findings:
         raise typer.Exit(1)
+
+
+@app.command(name="review-prep")
+def review_prep(
+    base: str | None = typer.Option(
+        None, "--base", "-b", help="Base branch/ref. Auto-detected (dev/main/master) if omitted."
+    ),
+    repo: Path = typer.Option(".", "--repo", "-r", help="Path to the repository."),
+    as_json: bool = typer.Option(
+        False, "--json", help="Emit structured JSON instead of the markdown payload."
+    ),
+) -> None:
+    """Trim a branch diff to the reviewable files before the review skill reads it.
+
+    Drops lockfiles, generated/vendored trees, minified/binary blobs, and pure
+    renames, then prints the trimmed diff plus an explicit manifest of what was
+    excluded (so nothing is hidden from the reviewer). Designed to be the diff
+    source the review skill consumes — fewer tokens in, faster review.
+    """
+    payload = prepare_review(repo=repo, base_branch=base)
+    if as_json:
+        import json
+
+        sys.stdout.write(json.dumps(render_dict(payload), indent=2) + "\n")
+    else:
+        sys.stdout.write(render_markdown(payload))
 
 
 def main() -> None:

--- a/src/klaussy/review_prep.py
+++ b/src/klaussy/review_prep.py
@@ -1,0 +1,259 @@
+"""Deterministic pre-processor for the review skill: trim a branch diff to what's
+actually worth reviewing before it reaches the model.
+
+A review's wall-clock is dominated by how many tokens the model has to read, and
+much of a large diff is noise no LLM should spend prefill or attention on:
+lockfiles, generated/vendored code, minified assets, binaries, pure renames.
+`prepare_review` runs the same `git diff` the skill would, drops those files
+deterministically, and returns both the trimmed reviewable diff and an explicit
+manifest of what was excluded and why — so nothing is silently hidden from the
+reviewer (silent truncation reads as "covered everything" when it didn't).
+
+This is the cheap, language-agnostic half of "make review faster": fewer tokens
+in. The expensive half (prompt-caching the diff across parallel sub-agents,
+model-tiering the lenses) lives in the skill/orchestration layer, not here.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# Dependency-manifest locks: huge, machine-generated, never hand-reviewed line by
+# line. The *manifest* change (package.json, pyproject.toml) stays reviewable;
+# only the lockfile is dropped.
+LOCKFILES = frozenset(
+    {
+        "package-lock.json",
+        "npm-shrinkwrap.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+        "poetry.lock",
+        "Pipfile.lock",
+        "uv.lock",
+        "pdm.lock",
+        "Cargo.lock",
+        "go.sum",
+        "Gemfile.lock",
+        "composer.lock",
+        "flake.lock",
+    }
+)
+
+# Any path component here marks a vendored / build-output / generated tree.
+NOISE_DIR_PARTS = frozenset(
+    {
+        "node_modules",
+        "vendor",
+        "dist",
+        "build",
+        "out",
+        ".next",
+        "__generated__",
+        "generated",
+        ".egg-info",
+    }
+)
+
+# Minified or sourcemap artifacts, plus common codegen suffixes.
+NOISE_SUFFIXES = (".min.js", ".min.css", ".map")
+GENERATED_SUFFIXES = (".pb.go", "_pb2.py", "_pb2_grpc.py", ".g.dart", ".freezed.dart")
+
+_DIFF_HEADER = re.compile(r"^diff --git a/(.+?) b/(.+)$")
+_BINARY = re.compile(r"^(Binary files .* differ|GIT binary patch)$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class FileDiff:
+    """One file's section of a unified diff, with cheap pre-computed stats."""
+
+    path: str
+    body: str
+    added: int
+    removed: int
+    binary: bool
+    has_hunks: bool
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Keep/drop verdict for one file, with the reason and its line counts."""
+
+    path: str
+    kept: bool
+    reason: str
+    added: int
+    removed: int
+
+
+@dataclass(frozen=True)
+class ReviewPayload:
+    """The trimmed diff plus the full keep/drop manifest."""
+
+    decisions: list[Decision]
+    trimmed_diff: str
+
+    @property
+    def kept(self) -> list[Decision]:
+        return [d for d in self.decisions if d.kept]
+
+    @property
+    def dropped(self) -> list[Decision]:
+        return [d for d in self.decisions if not d.kept]
+
+    @property
+    def kept_lines(self) -> int:
+        return sum(d.added + d.removed for d in self.kept)
+
+    @property
+    def dropped_lines(self) -> int:
+        return sum(d.added + d.removed for d in self.dropped)
+
+
+def _run_git(args: list[str], repo: Path) -> str:
+    out = subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {out.stderr.strip()}")
+    return out.stdout
+
+
+def split_file_diffs(diff_text: str) -> list[FileDiff]:
+    """Split a unified diff into per-file sections with stats."""
+    files: list[FileDiff] = []
+    # Keep the leading "diff --git" on each chunk by splitting with a lookahead.
+    chunks = re.split(r"(?m)^(?=diff --git )", diff_text)
+    for chunk in chunks:
+        if not chunk.strip():
+            continue
+        header = chunk.splitlines()[0]
+        m = _DIFF_HEADER.match(header)
+        if not m:
+            continue
+        # The b-side path is the post-change name (handles renames/adds); a delete
+        # shows `+++ /dev/null`, in which case the a-side name is the right label.
+        path = m.group(2)
+        if "+++ /dev/null" in chunk:
+            path = m.group(1)
+        added = removed = 0
+        has_hunks = False
+        for line in chunk.splitlines():
+            if line.startswith("@@ "):
+                has_hunks = True
+            elif line.startswith("+") and not line.startswith("+++"):
+                added += 1
+            elif line.startswith("-") and not line.startswith("---"):
+                removed += 1
+        files.append(
+            FileDiff(
+                path=path,
+                body=chunk if chunk.endswith("\n") else chunk + "\n",
+                added=added,
+                removed=removed,
+                binary=bool(_BINARY.search(chunk)),
+                has_hunks=has_hunks,
+            )
+        )
+    return files
+
+
+def classify(fd: FileDiff) -> tuple[bool, str]:
+    """Return (keep, reason) for one file diff."""
+    if fd.binary:
+        return False, "binary"
+    name = fd.path.rsplit("/", 1)[-1]
+    if name in LOCKFILES:
+        return False, "lockfile"
+    parts = set(fd.path.split("/"))
+    hit = parts & NOISE_DIR_PARTS
+    if hit:
+        return False, f"generated/vendored ({next(iter(hit))})"
+    if fd.path.endswith(NOISE_SUFFIXES):
+        return False, "minified/sourcemap"
+    if fd.path.endswith(GENERATED_SUFFIXES):
+        return False, "generated code"
+    if not fd.has_hunks:
+        return False, "no content change (rename/mode-only)"
+    return True, "reviewable"
+
+
+def prepare_review(repo: Path | str = ".", base_branch: str | None = None) -> ReviewPayload:
+    """Produce the trimmed reviewable diff + keep/drop manifest for a branch."""
+    repo = Path(repo).resolve()
+    base = base_branch or _detect_base(repo)
+    diff_text = _run_git(["diff", f"{base}...HEAD"], repo)
+
+    decisions: list[Decision] = []
+    kept_bodies: list[str] = []
+    for fd in split_file_diffs(diff_text):
+        keep, reason = classify(fd)
+        decisions.append(
+            Decision(path=fd.path, kept=keep, reason=reason, added=fd.added, removed=fd.removed)
+        )
+        if keep:
+            kept_bodies.append(fd.body)
+    return ReviewPayload(decisions=decisions, trimmed_diff="".join(kept_bodies))
+
+
+def _detect_base(repo: Path) -> str:
+    """First of dev/develop/main/master that the repo has; falls back to main."""
+    for branch in ("dev", "develop", "main", "master"):
+        out = subprocess.run(
+            ["git", "rev-parse", "--verify", branch],
+            cwd=str(repo),
+            capture_output=True,
+        )
+        if out.returncode == 0:
+            return branch
+    return "main"
+
+
+def render_markdown(payload: ReviewPayload) -> str:
+    """Render the payload for injection into the review skill's context."""
+    kept, dropped = payload.kept, payload.dropped
+    lines: list[str] = []
+    saved = payload.dropped_lines
+    summary = (
+        f"<!-- review-prep: {len(kept)} reviewable file(s), {payload.kept_lines} "
+        f"changed line(s); dropped {len(dropped)} file(s) / {saved} line(s) of noise -->"
+    )
+    lines.append(summary)
+    lines.append("")
+    lines.append("## Reviewable diff")
+    lines.append("")
+    if payload.trimmed_diff.strip():
+        lines.append("```diff")
+        lines.append(payload.trimmed_diff.rstrip("\n"))
+        lines.append("```")
+    else:
+        lines.append("_No reviewable changes after trimming._")
+    if dropped:
+        lines.append("")
+        lines.append(f"## Excluded from review ({len(dropped)} file(s))")
+        lines.append("")
+        lines.append("Dropped deterministically — skim only if a finding points here:")
+        lines.append("")
+        for d in dropped:
+            lines.append(f"- `{d.path}` — {d.reason} (+{d.added} / -{d.removed})")
+    return "\n".join(lines) + "\n"
+
+
+def render_dict(payload: ReviewPayload) -> dict:
+    """Structured form of the payload (for `--json`)."""
+    return {
+        "kept": [
+            {"path": d.path, "reason": d.reason, "added": d.added, "removed": d.removed}
+            for d in payload.kept
+        ],
+        "dropped": [
+            {"path": d.path, "reason": d.reason, "added": d.added, "removed": d.removed}
+            for d in payload.dropped
+        ],
+        "kept_lines": payload.kept_lines,
+        "dropped_lines": payload.dropped_lines,
+        "trimmed_diff": payload.trimmed_diff,
+    }

--- a/src/klaussy/templates/skills/review/SKILL.md
+++ b/src/klaussy/templates/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: {{REPO}}-review
 description: Use when the user wants a thorough PR or branch review. Triages by diff size — small PRs get a single-pass review, large PRs fan out to parallel sub-agents (correctness, architecture, security, scope, and an Agentic & Evals lens that activates on AI/agent code) with a validation phase that drops false positives.
-allowed-tools: Read Grep Glob Bash(git *) Write Agent
+allowed-tools: Read Grep Glob Bash(git *) Bash(klaussy review-prep *) Write Agent
 ---
 
 You are conducting a thorough PR review. Follow these phases in order.
@@ -34,9 +34,9 @@ git branch --show-current
 
 ### What you still need to do
 
-1. Run `git diff {{BASE_BRANCH}}...HEAD` to get the full diff (kept as a tool call rather than injected — diffs can be very large).
-2. **Read the full file (not just the diff hunks) for every changed file listed in the stat above.** These are independent reads — issue them all in a single batch of parallel tool calls, not sequentially.
-3. Count the total lines changed (additions + deletions) from the stat.
+1. **Get the reviewable diff.** Run `klaussy review-prep --base {{BASE_BRANCH}}`. It returns the diff trimmed to reviewable files — lockfiles, generated/vendored trees, minified/binary blobs, and pure renames are dropped — followed by an **Excluded from review** manifest listing what it dropped and why. Use this trimmed diff as *the diff* for the rest of the review. If the `klaussy` CLI isn't on PATH (the command errors), fall back to `git diff {{BASE_BRANCH}}...HEAD` for the full untrimmed diff and proceed as before. Kept as a tool call rather than injected — even trimmed, diffs can be large.
+2. **Read the full file (not just the diff hunks) for every *reviewable* changed file** — the files present in the trimmed diff, not the ones in the Excluded manifest. These are independent reads — issue them all in a single batch of parallel tool calls, not sequentially. The excluded files are deliberately out of scope: don't read or comment on them unless a finding in a reviewable file points directly at one.
+3. Count the total **reviewable** lines changed — use the `N changed line(s)` figure in the review-prep summary line (on the `git diff` fallback, take the `--stat` total but ignore any lockfile / generated / vendored / minified / binary files).
 4. If the branch name contains a ticket reference (e.g. FEAT-1234), note it for context.
 5. **Detect Architecture Decision Records / design docs.** Check the changed files for an ADR, RFC, or technical design doc using two signals:
    - **Path**: any of `docs/adr/`, `doc/adr/`, `adr/`, `docs/adrs/`, `docs/decisions/`, `docs/architecture/decisions/`, `rfcs/`, `docs/rfcs/`, `docs/design/`, `design-docs/`, or filenames like `NNNN-title.md`, `ADR-NNNN-*.md`, `*.adr.md`, `*.rfc.md`, `*.design.md`.
@@ -50,7 +50,7 @@ Store the diff output and file contents — you will need them in the next phase
 
 ## Phase 2: Triage
 
-Count the total lines changed from the `--stat` output.
+Count the total **reviewable** lines changed (from Phase 1 step 3 — the trimmed-diff figure, not the raw `--stat`, which still counts the dropped lockfile/generated/vendored noise).
 
 - **If < 150 lines changed:** proceed to [Small PR Review](#small-pr-review) below.
 - **If ≥ 150 lines changed:** proceed to [Parallel Review](#parallel-review) below.
@@ -156,7 +156,7 @@ Write this output to `REVIEW_OUTPUT.md`.
 This PR is large enough to benefit from focused, parallel review.
 
 1. **Read `.claude/skills/{{REPO}}-review/sub-agents.md`.** That file has the canonical list of sub-agent **Lens** sections plus a shared **Common scaffold** (intro, output format, ground rules). Some lenses are conditional — see step 3 for the detection-driven ones.
-2. **Compose each sub-agent's prompt** by concatenating: the Common scaffold (with `[PASTE THE FULL DIFF HERE]` and `[PASTE THE COMMIT LOG HERE]` replaced by the actual diff and log from Phase 1), then the sub-agent's Lens, then its Additional rules (if any). The "How to compose a sub-agent prompt" section at the top of `sub-agents.md` documents this exactly.
+2. **Compose each sub-agent's prompt** by concatenating: the Common scaffold (with `[PASTE THE FULL DIFF HERE]` and `[PASTE THE COMMIT LOG HERE]` replaced by the trimmed diff and commit log from Phase 1), then the sub-agent's Lens, then its Additional rules (if any). The "How to compose a sub-agent prompt" section at the top of `sub-agents.md` documents this exactly.
 3. **Decide whether to spawn sub-agent 5 (Agentic & Evals).** Skim the diff for AI / agent / eval signals — changes under `**/skills/**`, `**/agents/**`, `**/.claude/**`, MCP server files (`mcp_*.{py,ts,js}`, `mcp-server*.*`, `.mcp.json`), eval suites (`**/evals/**`, `eval_*.{py,ts,js}`, `*.eval.*`), or imports of `anthropic` / `openai` / `langchain` / `langgraph` / `mcp` / `@anthropic-ai/sdk` / `inspect_ai` / `langsmith` / `promptfoo`. If any signal is present, include sub-agent 5; otherwise skip it (it has nothing to review). The full detection list is at the top of sub-agent 5 in `sub-agents.md`.
 4. **Decide whether to spawn sub-agent 6 (Architecture Decision & Design-Doc).** If Phase 1 detected an ADR, RFC, or design doc, include sub-agent 6 and pass it the doc's full text; otherwise skip it. The detection signals are restated at the top of sub-agent 6 in `sub-agents.md`.
 5. **Use the Agent tool to launch all selected sub-agents in a single assistant message** — that gives you parallel execution. Each call passes `subagent_type: general-purpose` and the composed body from step 2. Sub-agents return findings as text and must NOT write any files.

--- a/tests/test_review_prep.py
+++ b/tests/test_review_prep.py
@@ -1,0 +1,139 @@
+"""Tests for the review-prep diff trimmer."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from klaussy.review_prep import (
+    classify,
+    prepare_review,
+    render_dict,
+    render_markdown,
+    split_file_diffs,
+)
+
+# A multi-file unified diff covering: a real source file, a lockfile, a vendored
+# tree, a minified asset, a binary, and a pure rename.
+SAMPLE_DIFF = """\
+diff --git a/src/app.py b/src/app.py
+index 1111111..2222222 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -1,3 +1,4 @@
+ def run():
+-    return 1
++    return 2
++    # changed
+diff --git a/package-lock.json b/package-lock.json
+index 3333333..4444444 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -1,5 +1,5 @@
+-  "old": 1
++  "new": 2
+diff --git a/node_modules/leftpad/index.js b/node_modules/leftpad/index.js
+index 5555555..6666666 100644
+--- a/node_modules/leftpad/index.js
++++ b/node_modules/leftpad/index.js
+@@ -1 +1 @@
+-module.exports = 1
++module.exports = 2
+diff --git a/static/app.min.js b/static/app.min.js
+index 7777777..8888888 100644
+--- a/static/app.min.js
++++ b/static/app.min.js
+@@ -1 +1 @@
+-var a=1
++var a=2
+diff --git a/assets/logo.png b/assets/logo.png
+index 9999999..aaaaaaa 100644
+Binary files a/assets/logo.png and b/assets/logo.png differ
+diff --git a/src/old_name.py b/src/new_name.py
+similarity index 100%
+rename from src/old_name.py
+rename to src/new_name.py
+"""
+
+
+def test_split_finds_every_file():
+    files = split_file_diffs(SAMPLE_DIFF)
+    paths = [f.path for f in files]
+    assert paths == [
+        "src/app.py",
+        "package-lock.json",
+        "node_modules/leftpad/index.js",
+        "static/app.min.js",
+        "assets/logo.png",
+        "src/new_name.py",
+    ]
+
+
+def test_counts_added_removed():
+    app = next(f for f in split_file_diffs(SAMPLE_DIFF) if f.path == "src/app.py")
+    assert (app.added, app.removed) == (2, 1)
+
+
+def test_classification_reasons():
+    by_path = {f.path: classify(f) for f in split_file_diffs(SAMPLE_DIFF)}
+    assert by_path["src/app.py"] == (True, "reviewable")
+    assert by_path["package-lock.json"][0] is False
+    assert by_path["package-lock.json"][1] == "lockfile"
+    assert by_path["node_modules/leftpad/index.js"][0] is False
+    assert "node_modules" in by_path["node_modules/leftpad/index.js"][1]
+    assert by_path["static/app.min.js"] == (False, "minified/sourcemap")
+    assert by_path["assets/logo.png"] == (False, "binary")
+    assert by_path["src/new_name.py"][0] is False  # pure rename, no hunks
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(repo), check=True, capture_output=True)
+
+
+def _commit_file(repo: Path, rel: str, content: str, msg: str) -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", msg)
+
+
+def test_prepare_review_keeps_source_drops_noise(tmp_path: Path):
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "t@t.t")
+    _git(tmp_path, "config", "user.name", "t")
+    _commit_file(tmp_path, "src/app.py", "def run():\n    return 1\n", "init")
+    _git(tmp_path, "branch", "-M", "main")
+    _git(tmp_path, "checkout", "-b", "feature")
+    # One real change + one lockfile change on the branch.
+    (tmp_path / "src/app.py").write_text("def run():\n    return 2\n")
+    (tmp_path / "package-lock.json").write_text('{"a": 2}\n')
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "work")
+
+    payload = prepare_review(repo=tmp_path, base_branch="main")
+    kept = {d.path for d in payload.kept}
+    dropped = {d.path for d in payload.dropped}
+    assert "src/app.py" in kept
+    assert "package-lock.json" in dropped
+    assert "package-lock.json" not in payload.trimmed_diff
+    assert "src/app.py" in payload.trimmed_diff
+
+
+def test_render_markdown_has_manifest_and_summary():
+    from klaussy.review_prep import Decision, ReviewPayload
+
+    pl = ReviewPayload(
+        decisions=[
+            Decision("src/app.py", True, "reviewable", 2, 1),
+            Decision("package-lock.json", False, "lockfile", 50, 40),
+        ],
+        trimmed_diff="diff --git a/src/app.py b/src/app.py\n+x\n",
+    )
+    md = render_markdown(pl)
+    assert "## Reviewable diff" in md
+    assert "## Excluded from review (1 file(s))" in md
+    assert "`package-lock.json` — lockfile" in md
+    assert "review-prep:" in md  # summary comment
+    d = render_dict(pl)
+    assert d["dropped_lines"] == 90 and d["kept_lines"] == 3


### PR DESCRIPTION
## Summary

Makes the `review` skill faster by cutting the tokens it reads. A review's wall-clock is dominated by how much diff the model has to ingest, and much of a large diff is noise an LLM should never spend prefill on. This adds a deterministic pre-processor and wires it into the skill.

Context: this is the language-agnostic "fewer tokens in" half of the review-speed plan. A Go/Rust sidecar isn't the lever — the work is I/O-bound git plumbing, and a compiled binary would break klaussy's pure-Python, pip-install-and-go distribution across 8 agents. So it ships as a CLI subcommand in the existing toolchain.

## Changes

- **`src/klaussy/review_prep.py`** — parses `git diff {base}...HEAD`, classifies each file, and drops lockfiles, generated/vendored trees (`node_modules/`, `vendor/`, `dist/`, …), minified/sourcemap/binary blobs, and pure renames. Returns the trimmed diff plus a keep/drop manifest with per-file line counts.
- **`klaussy review-prep`** CLI command — prints the trimmed diff + an **Excluded from review** manifest (markdown), or `--json`. No silent truncation: every dropped file is listed with the reason.
- **`review` skill (`SKILL.md`)** — Phase 1 now sources its diff from `klaussy review-prep --base {{BASE_BRANCH}}`, falling back to `git diff` when the CLI isn't on PATH; full-file reads and triage are scoped to the *reviewable* files. `allowed-tools` gains `Bash(klaussy review-prep *)`. The parallel sub-agents fan out over the trimmed diff.

## Impact

On a representative noisy PR (one real source change + a 600-line lockfile + a vendored file + a minified asset):

| | lines |
|---|---|
| Raw `git diff` (today) | 631 |
| Trimmed diff fed to the model | 11 |
| **Reduction** | **~98%** |

## Test Plan

- `tests/test_review_prep.py` (5 tests): diff splitting, add/remove counts, classification reasons per file type, end-to-end `prepare_review` on a real git repo, and markdown/JSON rendering.
- Full suite: **302 passed, 14 skipped**; `ruff check` clean.
- Scaffold check: the `review` skill substitutes all tokens and contains the wired command + updated `allowed-tools`.
- **Live-validated** the review eval (`KLAUSSY_RUN_EVALS=1`) after the wiring — still flags the planted SQL injection and stays civil (passed, ~20s).

## Follow-ups (not in this PR)

- The orchestration half: prompt-cache the diff across parallel sub-agents (avoid N× prefill), model-tier the lenses (cheap ones on Haiku).
- Optional: a size cap to window very large single-file changes.

## Checklist

- [x] Tests added
- [x] Skill wiring scaffolds + token-substitutes correctly
- [x] Review eval re-validated live
- [x] Lint passing, no unrelated files committed