### PR TITLE
feat(review): parallelize validation, add model-tiering guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
 ### Added
 
+- **Faster review orchestration** — the `review` skill's Phase 3 validation now
+  fans out: when sub-agents return more than 6 findings, it spawns parallel
+  validation sub-agents (one per batch) instead of a single sequential pass,
+  cutting the slowest serial stretch of a large review. Also added optional
+  model-tiering guidance — run the mechanical Scope & Conventions lens on a fast
+  model, keep the reasoning-heavy lenses and validators on the default model
+  (saves cost; latency comes from the parallel validation). Cross-sub-agent
+  prompt caching is intentionally *not* attempted: Claude Code gives each named
+  sub-agent a separate cache, so it isn't controllable from a skill — and
+  review-prep already shrank the per-sub-agent diff prefill.
 - **`klaussy review-prep` + faster review skill** — a deterministic diff
   pre-processor that trims a branch diff to the reviewable files (dropping
   lockfiles, generated/vendored trees, minified/binary blobs, and pure renames)

--- a/src/klaussy/templates/skills/review/SKILL.md
+++ b/src/klaussy/templates/skills/review/SKILL.md
@@ -161,13 +161,15 @@ This PR is large enough to benefit from focused, parallel review.
 4. **Decide whether to spawn sub-agent 6 (Architecture Decision & Design-Doc).** If Phase 1 detected an ADR, RFC, or design doc, include sub-agent 6 and pass it the doc's full text; otherwise skip it. The detection signals are restated at the top of sub-agent 6 in `sub-agents.md`.
 5. **Use the Agent tool to launch all selected sub-agents in a single assistant message** — that gives you parallel execution. Each call passes `subagent_type: general-purpose` and the composed body from step 2. Sub-agents return findings as text and must NOT write any files.
 
+**Model tiering (optional, if your sub-agent tool accepts a per-call model).** The lenses don't all need the same horsepower. Run the mechanical lens — **Sub-agent 4: Scope & Conventions**, which is mostly pattern-matching intent and checking conventions — on a fast, cheap model (e.g. `haiku`), and keep the reasoning-heavy lenses (correctness, architecture, security, agentic, ADR) on the default/inherited model where judgment earns its keep. Because the sub-agents run in parallel, this mainly saves **cost** rather than wall-clock (the cheap lens was never the slowest); the latency win comes from the parallel validation in Phase 3. If your tool has no per-call model control, run them all on the default model — tiering is an optimization, not a requirement.
+
 After all sub-agents return, proceed to Phase 3.
 
 ---
 
 ## Phase 3: Validation
 
-Before synthesizing, validate every finding from the sub-agents. For each finding:
+Before synthesizing, validate every finding from the sub-agents. The rubric for a single finding is:
 
 1. **Read the full file** referenced in the finding's location (not just the diff hunk).
 2. **Trace the code path** — follow function calls, imports, type definitions, and control flow to understand the full context. Read caller and callee files as needed.
@@ -181,7 +183,12 @@ Before synthesizing, validate every finding from the sub-agents. For each findin
 5. **Remove invalid findings.** Do not include them in the final output. Do not note that they were removed.
 6. **Downgrade severity** if tracing reveals the issue is less impactful than initially assessed (e.g., a "High" race condition that only affects a debug-only path should be "Low" or "Nit").
 
-Be thorough — read as many files as needed to verify each finding. A shorter, accurate review is far more valuable than a long review with false positives.
+**Validate in parallel when there are enough findings.** Reading files and tracing paths one finding at a time is the slowest *serial* stretch of a large review — every other phase before it fanned out, but this one doesn't by default. So:
+
+- **If the sub-agents returned more than 6 findings total:** partition them into batches of ~4–6 (group by file where you can, so a validator reads each file once) and spawn **one validation sub-agent per batch** with the Agent tool, all **in a single assistant message** (parallel). Compose each from `.claude/skills/{{REPO}}-review/sub-agents.md` → **Validation sub-agent**, passing it that batch of findings plus the trimmed diff; it reads whatever caller/callee files it needs and returns only the survivors (with the rubric applied and any severity downgrades). Collect all survivors, then go to Phase 4. Each validator must NOT write files.
+- **If there are 6 or fewer findings:** validate them inline yourself with the rubric above — the fan-out overhead isn't worth it.
+
+A shorter, accurate review is far more valuable than a long review with false positives.
 
 ---
 

--- a/src/klaussy/templates/skills/review/sub-agents.md
+++ b/src/klaussy/templates/skills/review/sub-agents.md
@@ -12,6 +12,8 @@ For each selected sub-agent, build the prompt body as:
 
 Then call the Agent tool with `subagent_type: general-purpose` and that composed body. Launch all selected sub-agents **in a single assistant message** (parallel tool calls), not sequentially. Each sub-agent must NOT write any files — they return findings as text.
 
+**Model tiering (optional).** If your sub-agent tool accepts a per-call model, run the mechanical lens (**Sub-agent 4: Scope & Conventions**) on a fast, cheap model (e.g. `haiku`) and keep the reasoning-heavy lenses on the default/inherited model. Running in parallel, this saves cost more than wall-clock. The **Validation sub-agent** below stays on the default model — dropping false positives is judgment work. No per-call model control? Run everything on the default model.
+
 ---
 
 ## Common scaffold (apply to every sub-agent)
@@ -331,4 +333,38 @@ the decision is sound, honestly argued, and matches the code.
   gaps = Medium/Low.
 - If the doc is genuinely complete and well-argued, say so in one line and return no
   findings. A good ADR is common; don't manufacture problems.
+```
+
+---
+
+## Validation sub-agent
+
+Used in Phase 3 when there are more than 6 findings to validate. Spawn one per batch of ~4–6 findings (grouped by file where possible), in parallel. Compose the prompt as: this block, with `[PASTE THE TRIMMED DIFF HERE]` and `[PASTE THE FINDINGS BATCH HERE]` replaced. Launch all validators in a single assistant message; each returns only the surviving findings as text and writes no files.
+
+```
+You are validating a batch of code-review findings before they ship. Your job is to drop false positives and fix overstated severity — not to find new issues. A shorter, accurate review beats a long one with noise.
+
+Here is the diff under review:
+[PASTE THE TRIMMED DIFF HERE]
+
+Here are the findings to validate (only these — ignore everything else):
+[PASTE THE FINDINGS BATCH HERE]
+
+For EACH finding, apply this rubric. Read whatever files you need — the referenced file in full, plus its callers and callees — using your tools.
+
+1. Read the full file at the finding's location, not just the diff hunk.
+2. Trace the code path: follow function calls, imports, type definitions, and control flow across files.
+3. Argue the author's side, then refute it. Write the strongest one-line case that this is NOT a real problem (the input can't occur, a caller already guards it, the framework handles it). Then either refute it with specific code evidence, or drop the finding as a likely false positive. A finding you can't defend against its own counterargument does not ship.
+4. Drop the finding if: the issue is already handled elsewhere (validation in a caller, error caught upstream); the code path can't actually be reached as the finding assumes; the finding misreads the logic from missing context; the concern is about unchanged code out of scope for this PR; or a dependency/framework already guarantees the behavior.
+5. Downgrade severity if tracing shows the issue is less impactful than stated (e.g. a "High" race that only affects a debug-only path is "Low" or "Nit").
+
+Return ONLY the findings that survive, each in this exact format, with severity reflecting any downgrade:
+
+**[Severity: Blocker | High | Medium | Low | Warn | Nit]**
+**[Location: file_path:line_number and code_snippet]**
+**Comment:**
+- What is wrong or questionable, why it matters
+- What to change (concrete fix or alternative)
+
+Do not include dropped findings, and do not note that you removed them. If none survive, say so in one line. Write no files.
 ```


### PR DESCRIPTION
## Summary

The orchestration-layer follow-up to #9. Speeds up the `review` skill's large-PR path by removing its one remaining serial bottleneck, and adds an optional cost lever. Scoped honestly to what a skill can actually control — verified against the Claude Code subagents docs before writing anything.

## Changes

- **Parallel validation (the latency win).** The parallel path fanned out the lenses but then validated every finding in a single *sequential* pass — the main agent reading files and tracing paths one finding at a time. Phase 3 now fans out: with more than 6 findings, it spawns parallel validation sub-agents (one per ~4–6 finding batch, grouped by file so each file is read once), each applying the argue-then-refute rubric with full file-read access and returning only the survivors. ≤6 findings still validate inline (fan-out isn't worth it). Adds a **Validation sub-agent** prompt to `sub-agents.md`.
- **Model tiering (a cost lever, not a latency one).** Optional guidance: run the mechanical Scope & Conventions lens on a fast model (e.g. `haiku`), keep the reasoning-heavy lenses and the validators on the default model. Because the lenses run in parallel, tiering the cheap one saves cost but not wall-clock — the skill says so plainly so nobody expects a speedup it won't deliver.

## What I deliberately did NOT do

My earlier follow-up list said "prompt-cache the diff across sub-agents." After verifying against the subagents docs: Claude Code gives each **named** sub-agent a **separate** cache, there's no cross-sub-agent prefix sharing, and `cache_control` isn't controllable from a skill prompt. So it's not achievable here, and the skill doesn't pretend to. review-prep (#9) already shrank the per-sub-agent diff prefill, which was the underlying concern.

## Test Plan

- Scaffold check: the `review` skill + `sub-agents.md` substitute all tokens (only `{{REPO_SPECIFIC_CHECKS}}` remains, as expected) and contain the new parallel-validation flow, tiering note, and Validation sub-agent prompt.
- Full suite: **302 passed, 14 skipped**; `ruff check` clean.
- **Review eval re-run live** (`KLAUSSY_RUN_EVALS=1`) — still flags the planted SQL injection and stays civil. (The eval exercises the small-PR path, so the new parallel branch isn't auto-tested; the large-PR orchestration is a prompt-spec change, called out here for transparency.)

## Checklist

- [x] Capability claims verified against docs before relying on them
- [x] Skill scaffolds + token-substitutes correctly
- [x] Review eval re-validated live
- [x] Honest framing of latency vs cost; no overclaiming