### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
-## [Unreleased]
+## [0.11.0] - 2026-06-28
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.10.0"
+version = "0.11.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, and Aider (Ollama)"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read


### PR DESCRIPTION
## Summary

Release prep for **v0.11.0**. Bumps the version (`pyproject.toml` + `__init__.py`) and finalizes the changelog (`[Unreleased]` → `[0.11.0]`).

Merging this and pushing the `v0.11.0` tag triggers the release workflow: test → build → **publish to PyPI** + GitHub Release.

## What's in 0.11.0 (since 0.10.0)

- **`review-prep` + faster review skill** (#9) — deterministic diff trimmer, ~98% fewer input lines on noisy PRs.
- **Review orchestration speedups** (#10) — parallel Phase 3 validation + optional model-tiering.
- **`slop-coded` skill** (#7) — the joke inverse of `humanize`.
- **`security-audit` eval** (#8) — planted-vulnerability precision check.

(0.10.0 itself — dependency gate, adr-generator/security-audit skills, shared session state — shipped in #6.)

## Test Plan

- Full suite: **302 passed, 14 skipped**; `ruff check` clean.
- Version consistent across `pyproject.toml` + `__init__.py`; `import klaussy` reports `0.11.0`.
- **Built locally** (`uv build`): sdist + wheel build cleanly, and the wheel includes the new modules and skill templates (`review_prep.py`, `dependency_guard.py`, `adr-generator`, `security-audit`, `slop-coded`).

## Checklist

- [x] Version bumped in both locations
- [x] Changelog finalized with date
- [x] Package builds; new templates packaged
- [x] Lint + tests green