### PR TITLE
fix(test): configure git identity in session branch test

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -33,6 +33,8 @@ def test_scaffolds_session_and_protocol(tmp_path: Path):
 
 def test_records_current_branch(tmp_path: Path):
     _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "t@t.co")
+    _git(tmp_path, "config", "user.name", "t")
     _git(tmp_path, "commit", "--allow-empty", "-m", "init")
     _git(tmp_path, "checkout", "-b", "feature/x")
     scaffold_session(repo=tmp_path)


### PR DESCRIPTION
## Summary

Fixes the test failure that blocked the v0.11.0 release run. `test_session.py::test_records_current_branch` ran `git commit` without configuring `user.email` / `user.name`, so it passed locally (global git config) but failed in CI with exit 128 ("Author identity unknown").

It surfaced only at release time because **pytest runs in CI on tag push (`release.yml`), not on PRs** — so this was the first CI test run since v0.9.0. The release job is gated on `needs: test`, so nothing was published to PyPI.

## Fix

Set the git identity right after `git init`, matching what the other git-using tests already do (`test_review_prep.py`, `test_cli.py`).

## Verification

Ran the full suite with global/system git config disabled to replicate CI's no-identity environment:

```
env -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \
    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null pytest tests/ -q
# 302 passed, 14 skipped
```

No other test has the same flaw.

## Follow-up (recommended, not in this PR)

Add a `pull_request` trigger for the test job so the suite runs on PRs, not only on release tags — this class of failure would then be caught before a release.