### PR TITLE
ci: run tests on PRs, gate PyPI publish to tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -30,6 +33,8 @@ jobs:
 
   release:
     needs: test
+    # Publish ONLY on a version tag push — never on pull requests.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: pypi
     steps:


### PR DESCRIPTION
## Summary

The `test` job (lint + pytest) only ran on tag pushes, so test breakages stayed hidden until release time — which is exactly how a missing git-identity in `test_session.py` slipped through and failed the first v0.11.0 release run. This adds a `pull_request` trigger so the suite runs on every PR to `main`.

## The important safety detail

Adding `pull_request` to `on:` naively would make the **release job publish to PyPI on every PR**. So the release job is now gated:

```yaml
release:
  needs: test
  if: startsWith(github.ref, 'refs/tags/v')   # tag pushes only, never PRs
```

- **On a PR** (`github.ref` = `refs/pull/N/merge`): only `test` runs. No publish.
- **On a `v*` tag push**: `test` → `release` (build + PyPI + GitHub Release), as before.

## Verification

- YAML validated locally (`yaml.safe_load`).
- This PR itself exercises the new trigger: the `test` job should now run on it (first time the suite runs on a PR), alongside gitleaks.

Self-validating: if the `test` check appears and passes on this PR, the trigger works.