### PR TITLE
docs: fix stale agent/skill counts and version refs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "klaussy",
-  "version": "0.2.0",
+  "version": "0.11.0",
   "description": "Claude Code boilerplate generator — scaffolds CLAUDE.md (path-scoped), namespaced .claude/skills/<repo>-<skill>/, settings, hooks, and PR template. Includes plugin-level klaussy-init and klaussy-update skills plus an MCP server.",
   "author": {
     "name": "Stephanie Dover",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in improving klaussy! It's a Python CLI that scaffolds
 conventions, skills, and hooks into repos for Claude Code, Gemini, Cursor,
-Codex, Copilot, and Antigravity.
+Codex, Copilot, Antigravity, Cline, and Aider.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **Write once, align everyone.** Keep your conventions in one central `CLAUDE.md` and let `klaussy` compile it into native rules, settings, and skills for Claude, Gemini, Cursor, Copilot, Codex, Google Antigravity, Cline, and Aider.
 
-Designed by an ex-GitHub, ex-Twitch, and ex-Microsoft engineer, `klaussy` is a multi-agent repository boilerplate generator. With a single command, it scaffolds conventions, repo-namespaced skills, stack-appropriate settings, and interactive guardrails for **seven major AI coding environments**—matching each agent's native file formats and capability profiles.
+Designed by an ex-GitHub, ex-Twitch, and ex-Microsoft engineer, `klaussy` is a multi-agent repository boilerplate generator. With a single command, it scaffolds conventions, repo-namespaced skills, stack-appropriate settings, and interactive guardrails for **eight major AI coding environments**—matching each agent's native file formats and capability profiles.
 
 ---
 
@@ -136,7 +136,7 @@ toolkit.init(repo=".", agents=["claude", "cursor"])
 
 ## 📜 Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.10.0** (dependency gate hook, `adr-generator` + `security-audit` skills, shared cross-agent session state).
+See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.11.0** (faster parallel review validation, `klaussy review-prep` diff trimming, `slop-coded` skill).
 
 ---
 

--- a/skills/klaussy-init/SKILL.md
+++ b/skills/klaussy-init/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: klaussy-init
-description: Use when the user wants to make this repository Claude Code-ready. Scaffolds CLAUDE.md (path-scoped via klaussy-repo-conventions), repo-namespaced .claude/skills/<repo>-<skill>/, settings.json, hooks, and a PR template — and runs once per repo.
+description: Use when the user wants to make this repository AI-agent-ready. Scaffolds per-agent conventions (CLAUDE.md / GEMINI.md / AGENTS.md / Cursor rules / Copilot instructions, path-scoped via klaussy-repo-conventions), repo-namespaced skills, settings, hooks, and a PR template for Claude Code, Gemini CLI, Cursor, Codex, GitHub Copilot, Google Antigravity, Cline, and Aider — and runs once per repo.
 argument-hint: "[--force] [--skip-enrich] [--base-branch <branch>]"
 allowed-tools: Read Bash(pipx *) Bash(klaussy *) Bash(pip *) Bash(git *)
 ---
 
 # Klaussy init
 
-Scaffold Claude Code boilerplate for the user's project by running klaussy.
+Scaffold AI coding-agent boilerplate for the user's project by running klaussy. By default this covers all eight supported agents — Claude Code, Gemini CLI, Cursor, Codex, GitHub Copilot, Google Antigravity, Cline, and Aider — from a single shared set of conventions.
 
 ## Steps
 
@@ -21,12 +21,12 @@ Scaffold Claude Code boilerplate for the user's project by running klaussy.
    ```
    If `.claude/skills/` or `./CLAUDE.md` already exists, ask the user whether to pass `--force` rather than assuming. The migration in `klaussy init` removes legacy `.claude/commands/*.md` files only if it owns them (via the `.klaussy-version` marker) — user-authored commands are left alone.
 
-   **Agent targets.** By default klaussy scaffolds **all** supported agents — Claude Code, Gemini CLI, Cursor, Codex, and GitHub Copilot — from the same conventions. Each gets the bundled skills in its own native `SKILL.md` directory (`.claude/skills/`, `.gemini/skills/`, `.cursor/skills/`, `.agents/skills/` for Codex, `.github/skills/` for Copilot), plus its native conventions file (`CLAUDE.md` / `GEMINI.md` / `AGENTS.md` / `.github/copilot-instructions.md` / `.cursor/rules/`) and permissions. To narrow to specific agents, pass `--agents claude,gemini` (any subset). If the user only uses Claude, suggest `--agents claude`.
+   **Agent targets.** By default klaussy scaffolds **all eight** supported agents — Claude Code, Gemini CLI, Cursor, Codex, GitHub Copilot, Google Antigravity, Cline, and Aider — from the same conventions. Each gets its native conventions file (e.g. `CLAUDE.md`, `GEMINI.md`, `AGENTS.md` for Codex/Antigravity, `.github/copilot-instructions.md`, `.cursor/rules/`, `.clinerules/conventions.md`, `CONVENTIONS.md` for Aider), plus the bundled skills in its native skills directory and permissions — except Aider, which is conventions-only (it has no skills or hooks mechanism). To narrow to specific agents, pass `--agents claude,gemini` (any subset). If the user only uses Claude, suggest `--agents claude`.
 
-4. **Verify output.** Confirm these landed:
+4. **Verify output.** The paths below are Claude Code's; each *other* selected agent gets the equivalent in its own dir (`.gemini/`, `.cursor/`, `.agents/` for Codex, `.github/` for Copilot) plus its native conventions file. Confirm these landed:
    - `./CLAUDE.md` at the repo root (with project-wide content)
    - `.claude/rules/<glob-stem>.md` for each path-scoped rule bucket klaussy-repo-conventions detected (zero or more files; some repos won't have any)
-   - `.claude/skills/<repo>-<skill>/SKILL.md` for 11 skills (review, plan, debug, implement, refactor, test, fix, pr, commit, explain, new-worktree)
+   - `.claude/skills/<repo>-<skill>/SKILL.md` for 16 skills (review, precommit, plan, debug, implement, refactor, test, fix, pr, commit, explain, humanize, new-worktree, adr-generator, security-audit, slop-coded)
    - `.claude/settings.json`
    - `.github/PULL_REQUEST_TEMPLATE.md` (only if the repo didn't already have one)
    - `.gitignore` updated with klaussy output exclusions
@@ -36,5 +36,5 @@ Scaffold Claude Code boilerplate for the user's project by running klaussy.
 ## When NOT to use
 
 - The repo is already klaussified at the same klaussy version — `klaussy init` will be a near-no-op; suggest the `klaussy-update` skill instead if the user actually wants to refresh.
-- The user wants a different scaffold tool (Cursor's setup, cookiecutter, an org-internal generator) — klaussy is Claude Code-specific.
+- The user wants a different scaffold tool (cookiecutter, an org-internal generator) — klaussy targets Claude Code, Gemini CLI, Cursor, Codex, Copilot, Antigravity, Cline, and Aider, and may not fit other setups.
 - The repo is empty or has no committed code yet — klaussy infers conventions from the existing code; an empty repo gets generic boilerplate that the user may want to defer until there's something to detect from.

--- a/skills/klaussy-update/SKILL.md
+++ b/skills/klaussy-update/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: klaussy-update
-description: Use when the user wants to refresh klaussy-generated boilerplate (skills, settings, hooks, CLAUDE.md) after upgrading klaussy itself. Re-runs the scaffold against the latest templates so this repo picks up new skills, prompt revisions, and convention rules.
+description: Use when the user wants to refresh klaussy-generated boilerplate (per-agent conventions, skills, settings, hooks) across every scaffolded agent after upgrading klaussy itself. Re-runs the scaffold against the latest templates so this repo picks up new skills, prompt revisions, and convention rules.
 argument-hint: "[--skip-enrich]"
 allowed-tools: Read Bash(pipx *) Bash(klaussy *) Bash(pip *) Bash(git *)
 ---
 
 # Klaussy update
 
-Refresh this repository's klaussy-generated boilerplate to match the latest klaussy version.
+Refresh this repository's klaussy-generated boilerplate to match the latest klaussy version, for every agent klaussy previously scaffolded (Claude Code, Gemini CLI, Cursor, Codex, GitHub Copilot, Google Antigravity, Cline, Aider).
 
 ## Steps
 
@@ -22,10 +22,10 @@ Refresh this repository's klaussy-generated boilerplate to match the latest klau
    klaussy init --force --base-branch <detected> $ARGUMENTS
    ```
 
-5. **Diff the result.** Run `git diff CLAUDE.md .claude/` and summarize the substantive changes for the user:
+5. **Diff the result.** Run `git diff` over the generated files for every scaffolded agent — Claude (`CLAUDE.md`, `.claude/`) plus any of `GEMINI.md`/`.gemini/`, `AGENTS.md` (Codex/Antigravity), `.cursor/`, `.github/copilot-instructions.md`/`.github/skills/`, `.clinerules/`, `CONVENTIONS.md` (Aider) that exist — and summarize the substantive changes for the user:
    - New skills added or removed
    - Prompt body changes in `<repo>-plan` / `<repo>-review` / etc.
-   - New / changed rule files under `.claude/rules/`
+   - New / changed rule files (e.g. under `.claude/rules/`)
    - Settings or hook changes
    This is the user's chance to review before committing the refresh.
 


### PR DESCRIPTION
## Summary

The docs disagreed on how many agents klaussy supports (variously 5, 6, or 7) and how many bundled skills ship (11 or 15). This reconciles all of them to the source of truth:

- **Agents** — `BACKENDS` in `agents/backends.py` (`DEFAULT = ALL`): **8** — claude, gemini, cursor, codex, copilot, antigravity, cline, aider.
- **Skills** — `SKILL_NAMES` in `skills.py`: **16**.

The trigger was noticing the `klaussy-init` plugin skill was framed as Claude-only despite `klaussy init` scaffolding every agent by default.

## Changes

- **`skills/klaussy-init` + `skills/klaussy-update`** — drop the Claude-only framing, list all 8 agents, note Aider is conventions-only (no skills/hooks); correct skill count 11 → 16 with the current list.
- **`README.md`** — "seven" → "eight" major environments; stale "latest release v0.10.0" → v0.11.0.
- **`CONTRIBUTING.md`** — add Cline and Aider to the supported-agent list (was 6).
- **`.claude-plugin/plugin.json`** — align plugin `version` 0.2.0 → 0.11.0 with the package.

`CHANGELOG.md`'s historical "seven agents" line is intentionally left intact — it's an accurate point-in-time record (the dependency-gate hook wired into the 7 hook-capable agents; Aider has no hooks).

## Test Plan

- Docs-only change; no code paths affected.
- Verified the 8-agent set and 16-skill set against `BACKENDS` and `SKILL_NAMES` in source.
- Grep sweep confirms no remaining "seven agents" / "11 skills" / "15 skills" / "v0.10.0" / "five agents" references outside the historical CHANGELOG entry.

## Checklist

- [x] Counts reconciled to source of truth
- [x] No code behavior changed
- [x] Historical CHANGELOG left intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)