### PR TITLE
fix(precommit): scope verbose-comment check to the diff (v0.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.12.1] - 2026-06-29
+
+### Fixed
+
+- **Verbose-comment precommit check only scans the diff** — `klaussy
+  comment-lint` gained a `--diff` flag (now used by the commit guards) that
+  scopes findings to lines changed vs `HEAD`. Previously the check read each
+  changed file in full, so a long pre-existing comment block anywhere in a
+  touched file blocked the commit even when the diff never went near it.
+  New/untracked files are still scanned in full. Because hook scaffolding is
+  version-gated on `.klaussy-version`, existing installs pick this up on a
+  re-run after the version bump (or with `--force`).
+
 ## [0.12.0] - 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ toolkit.init(repo=".", agents=["claude", "cursor"])
 
 ## 📜 Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.12.0** (hook scripts resolve from project root, tighter `humanize` output).
+See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.12.1** (verbose-comment precommit check scoped to the diff).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.12.0"
+version = "0.12.1"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, and Aider (Ollama)"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read

--- a/src/klaussy/cli.py
+++ b/src/klaussy/cli.py
@@ -13,6 +13,7 @@ from klaussy.agents import ALL_AGENTS, BACKENDS, resolve_agents
 from klaussy.checklist import generate_checklist
 from klaussy.claude_md import run_init
 from klaussy.comment_lint import analyze as analyze_comments
+from klaussy.comment_lint import changed_lines
 from klaussy.github import scaffold_github
 from klaussy.gitignore import update_gitignore
 from klaussy.humanize import humanize as humanize_text
@@ -291,6 +292,11 @@ def comment_lint(
     files: list[Path] = typer.Argument(
         ..., help="Source files to scan for over-long comment blocks."
     ),
+    diff: bool = typer.Option(
+        False,
+        "--diff",
+        help="Only flag comments overlapping lines changed vs HEAD (used by the precommit guard).",
+    ),
 ) -> None:
     """Flag verbose comments (block-only); exit 1 if any are found.
 
@@ -298,6 +304,9 @@ def comment_lint(
     catch narration comments ruff can't. It only reports — stripping a flagged
     comment to the bare minimum is left to the author. Unreadable files and
     unsupported languages are skipped silently.
+
+    With --diff, findings are scoped to lines that differ from HEAD, so
+    pre-existing comments elsewhere in a changed file don't block the commit.
     """
     findings = []
     for path in files:
@@ -305,7 +314,8 @@ def comment_lint(
             text = path.read_text()
         except (OSError, UnicodeDecodeError):
             continue
-        findings.extend(analyze_comments(str(path), text))
+        scope = changed_lines(str(path)) if diff else None
+        findings.extend(analyze_comments(str(path), text, scope))
 
     for finding in findings:
         console.print(finding.render())

--- a/src/klaussy/comment_lint.py
+++ b/src/klaussy/comment_lint.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 import re
+import subprocess
 import tokenize
 from dataclasses import dataclass
 from pathlib import Path
@@ -178,6 +179,55 @@ def _header_lines(prose: list[tuple[int, str]], first_code: int) -> set[int]:
     return header
 
 
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def changed_lines(path: str) -> set[int] | None:
+    """Working-tree line numbers added/changed vs HEAD for `path`.
+
+    Returns a set of 1-based line numbers that differ from HEAD, for scoping
+    findings to the diff in flight. Returns None — meaning "treat the whole
+    file as changed" — when the diff can't be trusted to under-report: git is
+    unavailable, the file is untracked/new (no HEAD version), or git errors.
+    An empty set means the file is tracked but has no changes vs HEAD.
+
+    Line numbers are read from `git diff HEAD` hunk headers, which index the
+    working-tree side — the same text `analyze()` reads from disk.
+    """
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "HEAD", "--unified=0", "--no-color", "--", path],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if diff.returncode != 0:
+        return None
+    if not diff.stdout.strip():
+        # No diff: either an unchanged tracked file (→ empty set, nothing to
+        # flag) or an untracked file with no HEAD side (→ whole file is new).
+        try:
+            tracked = subprocess.run(
+                ["git", "ls-files", "--error-unmatch", "--", path],
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return None
+        return set() if tracked.returncode == 0 else None
+
+    out: set[int] = set()
+    for line in diff.stdout.splitlines():
+        m = _HUNK_RE.match(line)
+        if not m:
+            continue
+        start = int(m.group(1))
+        count = 1 if m.group(2) is None else int(m.group(2))
+        out.update(range(start, start + count))
+    return out
+
+
 def _findings(path: str, text: str, records: list[_Record]) -> list[Finding]:
     findings: list[Finding] = []
     prose = [(ln, txt) for ln, full, txt in records if full and txt and not _is_directive(txt)]
@@ -217,8 +267,18 @@ def _findings(path: str, text: str, records: list[_Record]) -> list[Finding]:
     return findings
 
 
-def analyze(path: str, text: str) -> list[Finding]:
-    """Return verbose-comment findings for one file's text. Empty when clean."""
+def _overlaps(finding: Finding, scope: set[int]) -> bool:
+    return any(ln in scope for ln in range(finding.start, finding.end + 1))
+
+
+def analyze(path: str, text: str, scope: set[int] | None = None) -> list[Finding]:
+    """Return verbose-comment findings for one file's text. Empty when clean.
+
+    When `scope` is a set of line numbers, only findings that overlap those
+    lines are returned — used to limit the check to the diff in flight so
+    pre-existing comments elsewhere in the file don't block a commit. `None`
+    (the default) reports across the whole file.
+    """
     ext = Path(path).suffix.lower()
     if ext in _PY_EXT:
         records = _python_comments(text)
@@ -230,4 +290,7 @@ def analyze(path: str, text: str) -> list[Finding]:
         records = _slash_comments(text)
     else:
         return []
-    return _findings(path, text, records)
+    findings = _findings(path, text, records)
+    if scope is not None:
+        findings = [f for f in findings if _overlaps(f, scope)]
+    return findings

--- a/src/klaussy/templates/hooks/git_commit_guard.py
+++ b/src/klaussy/templates/hooks/git_commit_guard.py
@@ -32,10 +32,10 @@ LINT_CMD: str | None = "__KLAUSSY_LINT_CMD__"
 # Deterministic commented-out-code check (e.g. `ruff check --select ERA .`).
 # Block-only — it flags commented-out code; it does not delete it.
 COMMENT_CHECK_CMD: str | None = "__KLAUSSY_COMMENT_CHECK_CMD__"
-# Deterministic verbose-comment check; repo-independent (no sentinel), so a
-# literal. Block-only — flags over-long narration comments for the author to
-# trim, never edits them.
-VERBOSE_COMMENT_CMD: str | None = "klaussy comment-lint __KLAUSSY_PATHS__"
+# Deterministic verbose-comment check (block-only literal, no sentinel).
+# `--diff` scopes it to lines changed vs HEAD so pre-existing comments
+# elsewhere in a touched file don't block the commit.
+VERBOSE_COMMENT_CMD: str | None = "klaussy comment-lint --diff __KLAUSSY_PATHS__"
 
 # Stand-in for the files being committed; expanded just before each command runs.
 PATHS_TOKEN = "__KLAUSSY_PATHS__"

--- a/src/klaussy/templates/hooks/multi/commit_guard.py
+++ b/src/klaussy/templates/hooks/multi/commit_guard.py
@@ -36,10 +36,10 @@ FORMAT_CMD: str | None = "__KLAUSSY_FORMAT_CMD__"
 LINT_CMD: str | None = "__KLAUSSY_LINT_CMD__"
 # Deterministic commented-out-code check (block-only; flags, never deletes).
 COMMENT_CHECK_CMD: str | None = "__KLAUSSY_COMMENT_CHECK_CMD__"
-# Deterministic verbose-comment check; repo-independent, so a literal rather
-# than a sentinel. Block-only — flags over-long narration comments for the
-# author to trim, never edits them.
-VERBOSE_COMMENT_CMD: str | None = "klaussy comment-lint __KLAUSSY_PATHS__"
+# Deterministic verbose-comment check (block-only literal, no sentinel).
+# `--diff` scopes it to lines changed vs HEAD so pre-existing comments
+# elsewhere in a touched file don't block the commit.
+VERBOSE_COMMENT_CMD: str | None = "klaussy comment-lint --diff __KLAUSSY_PATHS__"
 
 # Stand-in for the files being committed; expanded just before each command runs.
 PATHS_TOKEN = "__KLAUSSY_PATHS__"

--- a/tests/test_comment_lint.py
+++ b/tests/test_comment_lint.py
@@ -1,10 +1,11 @@
 """Tests for the deterministic verbose-comment detector and its guard wiring."""
 
 import importlib.util
+import subprocess
 from pathlib import Path
 
 from klaussy import hooks as hooks_mod
-from klaussy.comment_lint import COMMENT_RUN_MAX, COMMENT_WORD_MAX, analyze
+from klaussy.comment_lint import COMMENT_RUN_MAX, COMMENT_WORD_MAX, analyze, changed_lines
 
 TEMPLATES = Path(hooks_mod.__file__).parent / "templates" / "hooks"
 
@@ -172,6 +173,77 @@ def test_render_format_single_and_range():
     assert "strip to the bare minimum" in rendered
 
 
+# --- diff scoping ----------------------------------------------------------
+
+
+_BLOCK = (
+    "x = 1\n"
+    "# this function takes the user input and validates it\n"
+    "# against the schema, then normalizes the casing because\n"
+    "# downstream code assumes lowercase, and finally returns\n"
+    "# the cleaned value to the caller for further processing\n"
+    "y = 2\n"
+)
+
+
+def test_scope_keeps_overlapping_finding():
+    # The block spans lines 2-5; a changed line inside it keeps the finding.
+    assert len(analyze("foo.py", _BLOCK, scope={4})) == 1
+
+
+def test_scope_drops_finding_outside_diff():
+    # No changed line touches the 2-5 block, so it's filtered out.
+    assert analyze("foo.py", _BLOCK, scope={1, 6}) == []
+
+
+def test_empty_scope_drops_everything():
+    assert analyze("foo.py", _BLOCK, scope=set()) == []
+
+
+def test_none_scope_reports_whole_file():
+    assert len(analyze("foo.py", _BLOCK, scope=None)) == 1
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+
+
+def test_changed_lines_reports_only_added_lines(tmp_path, monkeypatch):
+    repo = tmp_path
+    _init_repo(repo)
+    (repo / "f.py").write_text("a = 1\nb = 2\nc = 3\n")
+    _git(repo, "add", "f.py")
+    _git(repo, "commit", "-qm", "init")
+    (repo / "f.py").write_text("a = 1\nb = 2\nc = 3\n# new comment\n")
+    monkeypatch.chdir(repo)
+    assert changed_lines("f.py") == {4}
+
+
+def test_changed_lines_untracked_file_is_whole_file(tmp_path, monkeypatch):
+    repo = tmp_path
+    _init_repo(repo)
+    (repo / "new.py").write_text("x = 1\n")
+    monkeypatch.chdir(repo)
+    # No HEAD side — scope None means "report across the whole file".
+    assert changed_lines("new.py") is None
+
+
+def test_changed_lines_unchanged_tracked_file_is_empty(tmp_path, monkeypatch):
+    repo = tmp_path
+    _init_repo(repo)
+    (repo / "f.py").write_text("a = 1\n")
+    _git(repo, "add", "f.py")
+    _git(repo, "commit", "-qm", "init")
+    monkeypatch.chdir(repo)
+    assert changed_lines("f.py") == set()
+
+
 # --- guard wiring ----------------------------------------------------------
 
 
@@ -189,7 +261,7 @@ def test_commit_guards_run_the_verbose_check():
         ("multi/commit_guard.py", "_multi_commit_guard"),
     ):
         mod = _load_guard(relpath, name)
-        assert mod.VERBOSE_COMMENT_CMD == "klaussy comment-lint __KLAUSSY_PATHS__"
+        assert mod.VERBOSE_COMMENT_CMD == "klaussy comment-lint --diff __KLAUSSY_PATHS__"
         # PATHS placeholder resolves to the staged files, like the other checks.
         resolved = mod._resolve(mod.VERBOSE_COMMENT_CMD, ["a.py", "b.py"])
-        assert resolved == "klaussy comment-lint a.py b.py"
+        assert resolved == "klaussy comment-lint --diff a.py b.py"


### PR DESCRIPTION
## Summary

The verbose-comment precommit guard ran `klaussy comment-lint` on whole changed files, so a long pre-existing comment block anywhere in a touched file blocked the commit even when the diff never went near it. This scopes the check to the diff in flight.

## Changes

- `comment_lint.py`: add `changed_lines(path)` (parses `git diff HEAD -U0` hunk headers) and an optional `scope` arg to `analyze()` that keeps only findings overlapping changed lines. Untracked/new files and git-unavailable fail open (scan whole file).
- `cli.py`: `comment-lint` gains a `--diff` flag that computes the scope per file.
- Both commit guard templates now invoke `klaussy comment-lint --diff __KLAUSSY_PATHS__`.
- Version bump to **0.12.1** (`__init__.py`, `pyproject.toml`, `README.md`, `CHANGELOG.md`).

## Test Plan

- New unit tests for scope filtering (overlap/outside/empty/none).
- New git-backed tests for `changed_lines` (added lines, untracked file, unchanged tracked file).
- Updated guard-wiring assertions for the `--diff` command string.
- Full suite: 315 passed, 14 skipped; `ruff check` + `ruff format --check` clean.

## Checklist

- [x] Tests added/updated
- [x] Lint/format clean
- [x] CHANGELOG updated
- [x] Version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)