### PR TITLE
fix(skills): gate QA in rest-of-the-owl; block on unseen design assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.15.1] - 2026-07-14
+
+### Fixed
+
+- **`rest-of-the-owl` now treats QA as a blocking gate.** Phase 4 (QA) already
+  ran before the PR, but it was framed purely as evidence-gathering, so a change
+  QA had shown to be broken could still advance to a PR and get caught later by
+  CI or a reviewer. QA is now an explicit gate: a broken screenshot, wrong
+  endpoint response, CLI error, or failing test sends the run back to fix and
+  re-QA before the PR is opened.
+- **`plan` and `implement` block on design assets they can't see** instead of
+  inventing them. When a ticket references a mockup, screenshot, Figma link, or
+  attached image the agent has no tool to retrieve (`gh issue view` shows issue
+  text but not image attachments), the skills now hard-block and ask the user to
+  provide it rather than fabricating UI text, layout, spacing, or copy.
+
+### Changed
+
+- **`humanize` gains two review-reply rules:** no superlative or ranking praise
+  ("best catch", "the most important issue here"), and don't thank a bot —
+  respond to an automated reviewer's substance without gratitude aimed at it.
+
 ## [0.15.0] - 2026-07-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.15.0"
+version = "0.15.1"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), and opencode"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read

--- a/src/klaussy/skills.py
+++ b/src/klaussy/skills.py
@@ -69,11 +69,21 @@ HUMANIZE_BLOCK = "\n".join(
         ' hard, a brief acknowledgement or a question ("could we ...?", "one'
         ' risk is ...") takes the edge off. A light touch only, not filler praise'
         ' or "great job" boilerplate.',
+        "- **No superlatives or ranking praise.** Don't editorialize a point's"
+        ' importance: cut "this is the sharpest catch in the review", "best'
+        ' catch", "great find", "excellent point", "the most important issue'
+        ' here". Rating a comment against the others is an AI tell and adds'
+        " nothing. State the substance and stop.",
         "- **Don't mirror the thread's tone.** When you reply to an existing"
         " comment, review note, or message, read it for substance but not for"
         " temperature: neutralize any rudeness or bluntness in it before you"
         " draft. Hostile or curt input must not prime a hostile or curt reply,"
         " answer as if the other person had phrased it civilly.",
+        "- **Don't thank a bot.** When the reviewer is an automated tool or bot"
+        " (a review bot, another agent, a CI check), respond to the substance"
+        " without gratitude or pleasantries aimed at it, no \"thanks for the"
+        ' review", "good catch", or addressing it as a person. Reserve those'
+        " for a human reviewer, and even then keep them minimal.",
         "- **Be short, then cut more.** Lead with the point. Keep the decision and"
         " the one fact that justifies it, then stop. A reply in a thread is usually"
         " one sentence; a single review comment one to five. Don't pad to sound"

--- a/src/klaussy/templates/skills/implement/SKILL.md
+++ b/src/klaussy/templates/skills/implement/SKILL.md
@@ -15,6 +15,7 @@ Read the user's task description carefully. Identify:
 1. **What is being asked** — the specific deliverable or behavior change.
 2. **What is NOT being asked** — anything outside this scope is off-limits. Do not refactor, rename, restyle, or "improve" anything beyond the task. If you notice other issues, list them at the end but do NOT fix them.
 3. **Acceptance criteria** — extract every testable condition from the task. If the task is ambiguous or missing details that would change your approach, ask the user to clarify before proceeding. Do not guess at requirements — wrong assumptions compound into wrong implementations.
+4. **Referenced assets you can't see — block, don't invent.** If the task or ticket points at material you need but cannot retrieve — a mockup, screenshot, or design file attached to a GitHub/Jira issue; a Figma link; an image, spec, or doc you have no tool to open — stop and ask the user to provide it (paste the image, drop the file in the repo, share the copy/measurements). `gh issue view` shows an issue's text but does not download its image attachments, and a design you can't see is not one you can fabricate. Never make up UI text, layout, spacing, colors, or copy to keep moving — a plausible-looking invention looks done and is worse than a blocked task. This is a hard block: implementation cannot proceed past a design the human hasn't given you.
 
 ---
 

--- a/src/klaussy/templates/skills/plan/SKILL.md
+++ b/src/klaussy/templates/skills/plan/SKILL.md
@@ -23,6 +23,8 @@ Restate the user's request in your own words: what is being built, what problem 
 
 If any answer is "no", ask the user before exploring. Phase 3 covers the deeper "what should error handling do" / "what about edge case X" questions; Phase 1 catches the "do I even know what they want" case so the parallel agents don't waste effort on the wrong target.
 
+**Referenced-asset check — block, don't invent.** If the task or ticket points at material you need but cannot actually retrieve — a mockup, screenshot, or design file attached to a GitHub/Jira issue; a Figma link; an image, spec, or doc you have no tool to open — do NOT proceed by guessing what it contains. `gh issue view` shows an issue's text but does not download its image attachments, and a design you can't see is not a design you can fabricate. Stop and tell the user exactly which assets you're missing and ask them to provide them (paste the image, drop the file into the repo, share the copy/measurements). Never make up UI text, layout, spacing, colors, or copy to fill the gap — a plausible-looking invention is worse than a blocked task, because it looks done. This is a hard block: planning cannot continue past a design the human hasn't given you.
+
 Confirm with the user before continuing.
 
 ## Phase 2 — Understand (parallel exploration)
@@ -155,6 +157,7 @@ Write a 3–5 line summary: what was built, key decisions, files modified, sugge
 These apply regardless of the project. ALSO read this codebase's CLAUDE.md / `.claude/rules/*.md` / README / CONTRIBUTING early in Phase 2 to pick up project-specific rules and add them to your working list — local conventions usually beat generic advice when they conflict.
 
 - Skipping Phase 3 because the task "seems clear." Most clear-looking tasks have hidden ambiguities. Ask anyway.
+- Inventing design you can't see. When a ticket references an image or mockup you cannot download, block and ask for it (Phase 1) — never fabricate the UI text, layout, or copy to keep moving.
 - Adding features, abstractions, or refactors beyond what the task requires. YAGNI.
 - New abstractions for code with only one or two callsites. Three similar lines is fine.
 - Backwards-compatibility shims for code that has no other callers.

--- a/src/klaussy/templates/skills/rest-of-the-owl/SKILL.md
+++ b/src/klaussy/templates/skills/rest-of-the-owl/SKILL.md
@@ -38,6 +38,8 @@ Follow **`{{REPO}}-review`** against the working diff (`git diff {{BASE_BRANCH}}
 
 Follow **`{{REPO}}-qa`**. It classifies the diff and runs only the QA that fits: screenshots for a UI change, the exercised endpoint plus e2e for a backend change, command output for a CLI, tests for a library — and nothing at all for a docs/config-only change. Don't hand-pick the QA yourself; let the skill right-size it to what the diff touches. It saves artifacts to a `Downloads/<repo>-<branch>` folder where the user can open them — Phase 5 folds them into the PR so the reviewer sees the change actually working.
 
+**QA is a gate, not a formality — clear it before you touch the PR.** The whole point of running QA here is to catch problems *before* they become CI failures or reviewer comments. If QA surfaces anything wrong — a screenshot that shows the change is broken or ugly, an endpoint returning the wrong response, a CLI erroring, a failing test — stop and fix it: loop back to Phase 2/3, correct the change, and re-QA. Do NOT open the PR (Phase 5) on a change that QA has shown to be broken and then rely on CI or the reviewer to catch it. Only advance once QA is genuinely clean (or the only gaps are ones you've explicitly flagged as un-QA-able and told the user about).
+
 ## Phase 5 — Open the PR (humanized)
 
 1. Commit the work on a topic branch (never commit straight to `{{BASE_BRANCH}}`) and push.


### PR DESCRIPTION
## Summary

Three skill-behavior fixes reported from real runs, plus a version bump to 0.15.1.

## Changes

- **`rest-of-the-owl` — QA is now a blocking gate (Phase 4).** QA already ran before the PR, but was framed purely as evidence-gathering, so a change QA had shown broken could still advance to a PR and get caught later by CI or a reviewer. It's now an explicit gate: a broken screenshot, wrong endpoint response, CLI error, or failing test loops the run back to fix and re-QA before the PR opens.
- **`plan` and `implement` block on design assets they can't see.** When a ticket references a mockup, screenshot, Figma link, or attached image the agent has no tool to retrieve (`gh issue view` shows issue text, not image attachments), the skills now hard-block and ask the user to provide it instead of fabricating UI text, layout, spacing, or copy.
- **`humanize` gains two review-reply rules:** no superlative/ranking praise ("best catch", "the most important issue here"), and don't thank a bot.

## Test Plan

- `ruff check src/ tests/` — clean.
- Changes are skill-template markdown plus a humanize string block and version bumps; the pre-commit guard (silent failures, secrets, debug leftovers, landmines, lint) passed.
- CI runs the full `pytest` suite on this PR.

## Checklist

- [x] Version bumped in `pyproject.toml` and `src/klaussy/__init__.py`
- [x] `CHANGELOG.md` updated (0.15.1)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)