### PR TITLE
feat(skills): add grant-permissions skill, scoped per agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Every generated skill is namespaced to your repo, carries an auto-trigger descri
 | **`<repo>-self-review`** | Last-pass review of your own diff before "done". | 🪞 **AI-Tell Catcher:** Checks the uncommitted change against a fixed list — reuse, stdlib, comments, dead code, tests, scope — catching what makes a diff read as AI-written before a human ever sees it. A companion hook nudges the agent to run it. |
 | **`<repo>-qa`** | Captures PR-ready QA evidence for the current change. | 📸 **Change-Aware Verification:** Classifies the diff and runs only the QA that fits — screenshots for UI, exercised endpoints & e2e for backend, command output for a CLI, tests for a library — then saves artifacts to a `Downloads/<repo>-<branch>` folder where you can open them and writes a summary you can paste into the PR. |
 
-*Also bundles skills for `commit`, `pr`, `implement`, `refactor`, `explain`, `test`, `new-worktree`, `fix`, `deps`, `address-review`, `document`, `release`, and `adr-generator`.*
+*Also bundles skills for `commit`, `pr`, `implement`, `refactor`, `explain`, `test`, `new-worktree`, `fix`, `deps`, `address-review`, `document`, `release`, `adr-generator`, and `grant-permissions`.*
 
 <sub>🦉 And `<repo>-rest-of-the-owl` — hand it a task definition and it draws *the rest of the owl*: plans, implements, reviews and fixes, opens a humanized PR, then polls CI and code review, fixing findings and resolving threads until the PR is green and clean. Does everything except merge — the human keeps that button.</sub>
 

--- a/src/klaussy/agents/backends.py
+++ b/src/klaussy/agents/backends.py
@@ -379,6 +379,8 @@ class GeminiBackend(GenericBackend):
         plan_mode=False,
         keep_allowed_tools=False,
         keep_disable_invocation=False,
+        permissions_file="`.gemini/settings.json` (plus secret globs in `.geminiignore`)",
+        permission_syntax="the tool allow-list Gemini reads from that settings file",
     )
 
     def emit_conventions(self, repo, *, force):
@@ -435,6 +437,8 @@ class CursorBackend(GenericBackend):
         plan_mode=False,
         keep_allowed_tools=False,
         keep_disable_invocation=False,
+        permissions_file="`.cursor/permissions.json` (plus secret globs in `.cursorignore`)",
+        permission_syntax="its `allow` / `deny` arrays",
     )
 
     def emit_conventions(self, repo, *, force):
@@ -500,6 +504,11 @@ class CodexBackend(GenericBackend):
         # drop them so Codex falls back to its own defaults rather than mis-parse.
         keep_allowed_tools=False,
         keep_disable_invocation=False,
+        permissions_file=(
+            "`~/.codex/config.toml` — Codex ignores a project-local `.codex/config.toml` "
+            "for these settings, so they must live in your user config"
+        ),
+        permission_syntax="its `approval_policy` / `sandbox_mode` and trusted-command settings",
     )
 
     def emit_conventions(self, repo, *, force):
@@ -557,6 +566,11 @@ class CopilotBackend(GenericBackend):
         plan_mode=False,
         keep_allowed_tools=False,
         keep_disable_invocation=True,  # Copilot honors disable-model-invocation
+        permissions_file=(
+            "`~/.copilot/config.json` and CLI `--allow-tool` flags — Copilot's "
+            "allow-list is user-level config, not a committed repo file"
+        ),
+        permission_syntax="its tool-permission entries",
     )
 
     def emit_conventions(self, repo, *, force):
@@ -623,6 +637,11 @@ class AntigravityBackend(GenericBackend):
         # them so Antigravity falls back to its own defaults rather than mis-parse.
         keep_allowed_tools=False,
         keep_disable_invocation=False,
+        permissions_file="`.agents/settings.json`",
+        permission_syntax=(
+            "its allow-list (best-effort — Antigravity's committed permission "
+            "format isn't fully documented)"
+        ),
     )
 
     def emit_conventions(self, repo, *, force):
@@ -715,6 +734,12 @@ class ClineBackend(GenericBackend):
         # them so Cline falls back to its own defaults rather than mis-parse.
         keep_allowed_tools=False,
         keep_disable_invocation=False,
+        # No committed per-command allow-list: Cline's auto-approval is GUI-only.
+        permissions_file=None,
+        permission_syntax=(
+            "Cline's auto-approval is GUI-only — there's no committed allow-list "
+            "file, and `.clineignore` is the only committed control."
+        ),
     )
 
     def emit_conventions(self, repo, *, force):
@@ -844,6 +869,11 @@ class OpenCodeBackend(GenericBackend):
         plan_mode=False,
         keep_allowed_tools=False,
         keep_disable_invocation=False,
+        permissions_file="`opencode.json`",
+        permission_syntax=(
+            "its `permission.bash` and `permission.read` maps, which are "
+            "last-match-wins — put a broad default first and the specific rules after"
+        ),
         subagent_mechanism=(
             "use opencode's subagents: `@`-mention one (built-in `@general`, "
             "`@explore`, `@scout`, or a project-defined subagent) or let the "

--- a/src/klaussy/agents/base.py
+++ b/src/klaussy/agents/base.py
@@ -60,6 +60,11 @@ class CapabilityProfile:
     keep_disable_invocation: bool
     subagent_mechanism: str | None = None
     plan_mechanism: str | None = None
+    # Scopes the grant-permissions skill to this agent's own allow-list (via
+    # render.py). `permissions_file` is None when there's no committed one
+    # (Cline); `permission_syntax` then says what the agent gates on instead.
+    permissions_file: str | None = None
+    permission_syntax: str | None = None
 
 
 @dataclass

--- a/src/klaussy/agents/render.py
+++ b/src/klaussy/agents/render.py
@@ -24,6 +24,8 @@ import re
 
 from klaussy.agents.base import CapabilityProfile, SkillPayload
 
+_PERMISSIONS_TOKEN = "{{PERMISSIONS_TARGET}}"
+
 _DYNAMIC_BLOCK = re.compile(r"```!\n(.*?)\n```", re.DOTALL)
 _SUBAGENT_HINT = re.compile(
     r"sub-?agent|Agent tool|in parallel|subagent_type|launch \d", re.IGNORECASE
@@ -40,6 +42,47 @@ def _replace_dynamic_block(match: re.Match[str]) -> str:
         return f"Run `{commands[0]}` and use its output."
     bullets = "\n".join(f"- `{c}`" for c in commands)
     return "Run these commands and use their output:\n\n" + bullets
+
+
+def permission_target_markdown(
+    label: str, permissions_file: str | None, permission_syntax: str | None
+) -> str:
+    """Compose the agent-specific "where your allow-list lives" block.
+
+    Replaces the `{{PERMISSIONS_TARGET}}` sentinel in the grant-permissions
+    skill so each agent's copy is scoped to its own permission file and rule
+    shape instead of carrying a table of all agents. When `permissions_file`
+    is None the agent has no committed per-command allow-list; `permission_syntax`
+    then explains what it gates on instead.
+    """
+    header = "## Where your allow-list lives\n"
+    if permissions_file:
+        return (
+            f"{header}\n"
+            f"You're running **{label}**. Write permissions to {permissions_file}, "
+            f"using {permission_syntax}. Prefer the local, git-ignored file so one "
+            "developer's convenience list isn't committed onto the team; only write "
+            "a shared, committed file if the user asks to apply it team-wide. The "
+            "rule examples below use Claude Code's `Bash(...)` / `Edit(...)` form, "
+            "translate them to your file's shape."
+        )
+    return (
+        f"{header}\n"
+        f"You're running **{label}**. {permission_syntax} So this skill's "
+        "file-writing steps don't apply as written; tell the user that plainly, and "
+        "where the agent has an equivalent control (an ignore file, a settings UI, a "
+        "test/lint gate) point them at it instead of writing an allow-list."
+    )
+
+
+def _apply_permission_target(text: str, profile: CapabilityProfile) -> str:
+    """Resolve the `{{PERMISSIONS_TARGET}}` sentinel for this profile, if present."""
+    if _PERMISSIONS_TOKEN not in text:
+        return text
+    block = permission_target_markdown(
+        profile.label, profile.permissions_file, profile.permission_syntax
+    )
+    return text.replace(_PERMISSIONS_TOKEN, block)
 
 
 def _capability_banner(body: str, profile: CapabilityProfile) -> str:
@@ -95,6 +138,7 @@ def adapt_body(body: str, profile: CapabilityProfile) -> str:
         text = _DYNAMIC_BLOCK.sub(_replace_dynamic_block, text)
     if profile.skills_root != ".claude/skills":
         text = text.replace(".claude/skills/", f"{profile.skills_root}/")
+    text = _apply_permission_target(text, profile)
     # Detect capabilities against the adapted text: a subagent/plan-mode mention
     # that lived inside a stripped ```! block shouldn't trigger a banner.
     return _capability_banner(text, profile) + text

--- a/src/klaussy/skills.py
+++ b/src/klaussy/skills.py
@@ -10,6 +10,18 @@ from klaussy import __version__
 
 console = Console()
 
+# Claude's own permission surface for the grant-permissions {{PERMISSIONS_TARGET}}
+# sentinel — the Claude scaffold path skips render.py, so it feeds these through
+# the same composer (imported lazily to avoid a skills<->render cycle).
+_CLAUDE_PERMISSIONS_FILE = (
+    "`.claude/settings.local.json` (personal, git-ignored) or "
+    "`.claude/settings.json` (shared with the team)"
+)
+_CLAUDE_PERMISSION_SYNTAX = (
+    "a `permissions.allow` / `permissions.deny` array of string rules like "
+    "`Bash(git *)`, `Edit(**)`, and `Read(**)`"
+)
+
 SKILL_NAMES = [
     "review",
     "precommit",
@@ -35,6 +47,7 @@ SKILL_NAMES = [
     "security-audit",
     "slop-coded",
     "rest-of-the-owl",
+    "grant-permissions",
 ]
 
 VERSION_FILE = ".klaussy-version"
@@ -240,11 +253,18 @@ def scaffold_skills(
 
     repo_namespace = sanitize_skill_namespace(repo.name)
 
+    from klaussy.agents.render import permission_target_markdown
+
+    claude_permissions_target = permission_target_markdown(
+        "Claude Code", _CLAUDE_PERMISSIONS_FILE, _CLAUDE_PERMISSION_SYNTAX
+    )
+
     def _substitute(text: str) -> str:
         return (
             text.replace("{{REPO}}", repo_namespace)
             .replace("{{BASE_BRANCH}}", base_branch)
             .replace("{{HUMANIZE}}", HUMANIZE_BLOCK)
+            .replace("{{PERMISSIONS_TARGET}}", claude_permissions_target)
         )
 
     for skill in SKILL_NAMES:

--- a/src/klaussy/templates/skills/grant-permissions/SKILL.md
+++ b/src/klaussy/templates/skills/grant-permissions/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: {{REPO}}-grant-permissions
+description: Use when the user is tired of approving the same routine dev commands ("stop asking me yes", "allow the normal dev tools", "grant permissions"). Detects the repo's stack and writes a curated allow-list into the agent's own local permission file so everyday commands (tests, lint, build, git, package manager, run) stop prompting, while keeping secret files denied.
+allowed-tools: Read Edit Bash Grep Glob
+---
+
+Grant the permissions a developer needs to work in this repo without a prompt on every routine command, while keeping sensitive files off-limits.
+
+Permissions live in your agent's config file, not in memory or preferences — this skill edits that file. It does NOT loosen anything silently: propose the allow-list, show it, then write it.
+
+{{PERMISSIONS_TARGET}}
+
+## Steps
+
+1. **Find the repo's real commands.** Read CLAUDE.md and any rules files first. If there's no CLAUDE.md (common on third-party repos), fall back to `README.md`, `CONTRIBUTING.md`, `package.json` `scripts`, a `Makefile`/`justfile`/`Taskfile.yml`, and a `scripts/` directory. Capture test, lint, format, type-check, build, and especially the **run/dev/start** command — that's the one people forget to allow.
+2. **Detect the stack and its runner** from marker files:
+   - `pyproject.toml` / `setup.py` → `python`, `pytest`, `ruff`, `mypy`/`pyright`, `pip`, `uv`
+   - `package.json` → `npm`, `npx`, `node`, `yarn`, `pnpm` (read its `scripts`)
+   - `go.mod` → `go`; `Cargo.toml` → `cargo`; `Makefile` → `make`
+   - `docker-compose.yml` / `Dockerfile` → `docker`, `docker compose`
+   - **A `scripts/` directory or a Makefile is the entrypoint in many repos** (FastAPI runs `bash scripts/test.sh`; httpx runs `scripts/test`, `scripts/check`, `scripts/lint`). A `Bash(pytest *)` rule does NOT cover `scripts/test` — allow the runner itself (next step) or the tests still prompt.
+3. **Read the current permission file(s)** so you merge instead of clobbering. Preserve every existing allow/deny entry and any hook config.
+4. **Build the allow-list** (curated mode — the default):
+   - `Read`, `Edit`, `Grep`, `Glob` (bare tool names)
+   - `Bash(git *)`
+   - **Navigation/inspection builtins** that otherwise block compound commands (see the compound-command note): `Bash(cd *)`, `Bash(ls *)`, `Bash(pwd)`, `Bash(echo *)`, `Bash(mkdir *)`, `Bash(which *)`, `Bash(cat *)`, `Bash(head *)`, `Bash(tail *)`, `Bash(wc *)`, `Bash(find *)`, `Bash(rg *)`, `Bash(sort *)`
+   - one `Bash(<tool> *)` per stack command from step 2 (e.g. `Bash(pytest *)`, `Bash(npm *)`, `Bash(cargo *)`)
+   - **the repo's runner** if it uses one: `Bash(bash scripts/*)`, `Bash(sh scripts/*)`, `Bash(./scripts/*)`, `Bash(scripts/*)`, `Bash(make *)`
+   - **the run/dev command** as its own entry (e.g. `Bash(fastapi dev *)`, `Bash(uvicorn *)`, `Bash(npm run dev *)`, `Bash(docker compose *)`)
+5. **Keep sensitive files denied.** Add to `deny` if absent (see the `Edit` vs `Write` rule below): `Read(**/.env)` + `Edit(**/.env)`, and the same pair for `**/.env.*`, `**/.envrc`, `**/credentials.json`, `**/.aws/credentials`, `**/.npmrc`, `**/*.pem`, `**/*.key`, `**/id_rsa`, `**/id_ed25519`. For agents with an ignore file (`.cursorignore`, `.geminiignore`), add the secret globs there too — those block Bash reads that per-tool deny rules miss (see safety note).
+6. **Merge and write.** Union new entries into the existing arrays, drop exact duplicates, write valid JSON (or the agent's format). Report exactly what you added.
+7. **Tell the user how to widen or narrow it** — that broad mode exists, and that removing an entry re-enables its prompt.
+
+## Why `cd` and the builtins matter: compound commands
+
+A Bash rule matches by prefix (`Bash(git *)` matches anything starting with `git `). But the agent splits a compound command on `&&`, `||`, `;`, and `|` and checks **each segment separately** — the line runs unprompted only if *every* segment matches.
+
+So `cd services/api && npm run dev` prompts even when `Bash(npm run dev *)` is allowed, because the `cd services/api` segment isn't. That's the top reason a "fully allowed" toolchain still asks — run, test, and build commands are routinely prefixed with `cd`. Allowing `cd` plus the read builtins closes it. Match the syntax exactly: `Bash(cd *)` with a **space** before `*`, not a colon.
+
+## What curated mode does and doesn't protect (the safe boundary)
+
+Curated mode is a reasonable boundary for a **trusted local dev agent**, not a security sandbox. Be honest with the user about the line:
+
+- **It does** stop routine prompts, block obviously-destructive arbitrary shell (no blanket `Bash(*)`), and prevent accidental *edits* to secret files via the Read/Edit tools.
+- **It does not** sandbox execution. `Bash(python *)`, `Bash(pip *)`, `Bash(uv *)`, and `Bash(npx *)` all run arbitrary code (a language runtime executes anything; `pip install` runs a package's setup code). Only allow these for an agent you trust to run this repo's code — which is the normal case for local dev, but say it out loud.
+- **Per-tool deny is not a wall against Bash.** A `deny` on `Read(**/.env)` only stops the *Read tool*; `Bash(cat *)` can still `cat .env`. So the secret-file denies protect Read/Edit, not Bash. If secrets in the repo are a real concern, either don't allow `Bash(cat *)`/`Bash(head *)` (read files with the Read tool, which honors deny) or add the secret globs to the agent's ignore file (`.cursorignore`/`.geminiignore`), which some agents enforce for Bash too. Don't claim the denies protect against Bash — they don't.
+- **Deliberately excluded from the default builtins:** `source`/`.` (executes an arbitrary file), `env`/`printenv` (dumps secrets in the environment), `eval`, `xargs`. Add them only on request.
+
+## Broad mode (only when the user asks)
+
+For the fewest prompts, accepting the wider blast radius, replace the curated Bash entries with `Bash(*)`, and `Edit(**)` / `Read(**)`. Keep the step-5 denies (deny wins over allow), and keep the ignore-file globs, since `Bash(*)` makes the Bash-bypass above trivial. Say plainly that broad mode trusts the agent with arbitrary commands; never pick it by default.
+
+## Cross-platform
+
+Permission rule *strings* are OS-agnostic — the same `Bash(pytest *)` works on macOS, Linux, and Windows. Two things do differ:
+
+- **Windows shells.** Claude Code and most agents run Bash through Git Bash or WSL, so the POSIX builtins above (`cd`, `ls`, `cat`) still apply. If the user drives commands through native `cmd`/PowerShell instead, `dir`/`type`/`Get-ChildItem` won't match POSIX rules — allow those variants for that user.
+- **Run-command paths.** Write run/dev commands with forward slashes and no OS-specific absolute paths (`Bash(cd services/api *)`, not a `C:\...` path), so the same local file works across a mixed-OS team. That's also why the personal, git-ignored file is the right default target.
+
+## The one rule that trips people up: `Edit(<path>)`, never `Write(<path>)`
+
+Path-scoped rules are matched by the file-permission checker, and (in Claude Code) that checker **only understands `Edit(<path>)`** — an `Edit` rule covers every file-editing tool, Write included. A `Write(<path>)` path rule (allow OR deny) is silently ignored: it matches nothing, protects nothing, and produces a startup warning.
+
+- Deny a file: `Edit(**/*.pem)`. Don't add a redundant `Write(**/*.pem)` — it only triggers the warning.
+- Allow file edits broadly: `Edit(**)`. A bare `Write` (no parens) in `allow` is fine; `Write(**)` as a path rule is not.
+- If the file already pairs `Edit(<path>)` + `Write(<path>)`, the `Write(<path>)` ones are dead weight — offer to strip them.
+
+## When NOT to use
+
+- The user wants to change *what* an agent does, not what it's allowed to do — that's a conventions/skill change.
+- The user wants an automatic behavior on every tool call (block X, run Y after Z) — that's a hook, not a permission rule.
+- A single one-off command needs approving — just approve it; don't rewrite the allow-list for one prompt.
+- The user asks to allow something dangerous with no scope (`Bash(rm -rf *)`, dropping all denies) — surface the risk and confirm first.
+- The agent is Aider (or any tool without a per-command allow-list) — there's nothing to grant; explain the gating it does have instead.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -789,6 +789,45 @@ class TestRenderAdapt:
         out = render_skill_md(payload, CopilotBackend().profile)
         assert "disable-model-invocation: true" in out
 
+    def test_permissions_target_scoped_to_backends_own_file(self):
+        # The grant-permissions {{PERMISSIONS_TARGET}} sentinel must resolve to
+        # each agent's OWN permission file, never leak the raw token, and never
+        # show another agent's file.
+        from klaussy.agents.backends import CursorBackend, GeminiBackend, OpenCodeBackend
+        from klaussy.agents.render import adapt_body
+
+        body = "before\n{{PERMISSIONS_TARGET}}\nafter"
+
+        gemini = adapt_body(body, GeminiBackend().profile)
+        assert "{{PERMISSIONS_TARGET}}" not in gemini
+        assert "`.gemini/settings.json`" in gemini
+        assert ".cursor/permissions.json" not in gemini
+
+        cursor = adapt_body(body, CursorBackend().profile)
+        assert "`.cursor/permissions.json`" in cursor
+
+        # opencode's last-match-wins syntax note rides on the same field.
+        opencode = adapt_body(body, OpenCodeBackend().profile)
+        assert "last-match-wins" in opencode
+
+    def test_permissions_target_none_branch_for_gui_only_agent(self):
+        # Cline has no committed allow-list file: the sentinel must render the
+        # "doesn't apply" explanation, not a bogus file path.
+        from klaussy.agents.backends import ClineBackend
+        from klaussy.agents.render import adapt_body
+
+        out = adapt_body("{{PERMISSIONS_TARGET}}", ClineBackend().profile)
+        assert "{{PERMISSIONS_TARGET}}" not in out
+        assert "GUI-only" in out
+        assert "Write permissions to" not in out  # no file-writing instruction
+
+    def test_permissions_target_absent_leaves_body_untouched(self, gemini_profile):
+        # Skills without the sentinel must be unaffected by the resolution step.
+        from klaussy.agents.render import adapt_body
+
+        out = adapt_body("A skill with no permissions token.", gemini_profile)
+        assert "Where your allow-list lives" not in out
+
 
 class TestMultiAgentBackends:
     def test_gemini_writes_skills_and_conventions(self, repo_with_claude_md: Path):


### PR DESCRIPTION
## Summary

Adds a new repo-namespaced skill, `<repo>-grant-permissions`, that grants the typical dev permissions a developer needs so routine commands stop prompting ("stop asking me yes"), while keeping secret files denied. It's scoped to **each agent's own permission surface** at generation time, not a one-size table every agent carries.

Motivation: a user kept re-approving the same routine commands. The skill detects the stack and writes a curated allow-list into the agent's own local permission file.

## Changes

- **New skill** `templates/skills/grant-permissions/SKILL.md`; added to canonical `SKILL_NAMES` (now 25); README updated.
- **Curated allow-list logic**: git + detected toolchain, shell builtins (so compound `cd x && <cmd>` lines don't prompt), **`scripts/`/Makefile runners** (both FastAPI and httpx drive their dev loop through these — a bare `Bash(pytest *)` rule misses them), and the app's run/dev command. Keeps secret-file denies. Honest safety boundary documented (curated mode trusts the agent to run repo code; per-tool denies don't stop Bash reads of secret files). Broad mode is opt-in only.
- **Per-agent scoping** via a new `{{PERMISSIONS_TARGET}}` sentinel:
  - `CapabilityProfile` gains `permissions_file` + `permission_syntax` (`agents/base.py`).
  - `render.py` resolves the sentinel per profile (`permission_target_markdown` + `_apply_permission_target`).
  - The Claude scaffold path (which bypasses `render.py`) feeds Claude's own file+syntax through the same composer — lazy import to avoid a `base<->skills<->render` cycle.
  - All 7 skill-rendering backends set accurate values (Gemini, Cursor, Codex, Copilot, Antigravity, OpenCode, and Cline's no-committed-allow-list "doesn't apply" branch). Aider defines no profile, so it never renders the skill.
- **Cross-platform**: rule strings are OS-agnostic; notes on Windows shells and forward-slash run-command paths.
- **The `Edit(<path>)`-not-`Write(<path>)` rule** baked in — `Write(<path>)` path rules are silently ignored by the permission checker (the root cause of a real warning that prompted this work).

## Test Plan

- `pytest` — 485 passed, 15 skipped.
- New tests in `TestRenderAdapt`: per-backend scoping renders each agent's own file with no token leak and no cross-agent bleed; Cline None-branch renders the "doesn't apply" text; skills without the sentinel are untouched.
- Verified both generation paths resolve `{{PERMISSIONS_TARGET}}`: generic backends via `render_skill_md`, Claude via `scaffold_skills`.
- Dry-ran the skill's logic against real `fastapi` and `httpx` clones — surfaced (and fixed) the `scripts/`-runner gap.
- `ruff check` / `ruff format --check` clean.

## Checklist

- [x] Tests pass locally
- [x] Lint/format clean
- [x] Conventional Commit title
- [x] No secrets or debug leftovers
- [x] Docs updated (README skill list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)