### PR TITLE
Release 0.19.3: humanize rules for empty emphasis, invented consensus, author swipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.19.3] - 2026-07-25
+
+### Added
+
+- **Three new rules in the shared humanize block**, so every prose-output skill
+  picks them up. No `actual` or `actually`, and no swapping in
+  `real`/`really`/`genuinely`/`truly` — all of them are empty emphasis, and "it
+  actually works" is "it works". No invented consensus (`most people expect
+  this`, `everyone does it this way`, `it's widely considered best practice`) —
+  argue from the code, a repo convention, or a linkable source, or own the claim.
+  And no `nobody asked for this` or its paraphrases, which read as a swipe at the
+  author instead of an objection about the code.
+- **The scrubber enforces the first rule deterministically.** `Actually` joins the
+  filler-opener list, and new rules drop the adverb mid-sentence, at a sentence
+  start, and trailing with its comma. The adjective goes only after a determiner
+  that doesn't inflect, so "an actual bug" never becomes "an bug", and only when
+  the next word can head a noun phrase, so "compare the actual to the expected"
+  is left intact. `real` stays prompt-side entirely, since deleting it flips
+  meaning ("real user data, not fixtures").
+- **`slop-coded` gained the matching tells** (empty emphasis, invented consensus)
+  so the evil twin still produces what humanize strips.
+
+### Changed
+
+- The `review` and `slop-coded` skill templates drop their own uses of the words
+  the new rules ban.
+
+**Note:** `examples/fastapi` and `examples/httpx` still carry the 0.19.2 skill
+output and will be regenerated in a later release.
+
 ## [0.19.2] - 2026-07-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Every generated skill is namespaced to your repo, carries an auto-trigger descri
 
 *Also bundles skills for `commit`, `pr`, `implement`, `refactor`, `explain`, `test`, `new-worktree`, `fix`, `deps`, `address-review`, `document`, `release`, and `adr-generator`.*
 
-<sub>🥚 And `<repo>-slop-coded` — the evil twin of `humanize` that turns clean prose into maximal AI slop. For laughs and stress-testing the scrubber; never run it on a real deliverable.</sub>
+<sub>🥚 And `<repo>-slop-coded` — the evil twin of `humanize` that turns clean prose into maximal AI slop. For laughs and stress-testing the scrubber; never run it on a deliverable.</sub>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ toolkit.init(repo=".", agents=["claude", "cursor"])
 
 ## 📜 Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.19.2** (the commit guard now runs when a commit stages its own files, and `comment-lint` findings stay on one line).
+See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.19.3** (the humanize rules now ban empty emphasis like `actual`/`really`, invented consensus like `most people expect this`, and swipes at the author like `nobody asked for this`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.19.2"
+version = "0.19.3"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), and opencode"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.19.2"
+__version__ = "0.19.3"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read

--- a/src/klaussy/humanize.py
+++ b/src/klaussy/humanize.py
@@ -12,6 +12,7 @@ Conservative by design — high-confidence, meaning-preserving edits only:
 - strip sentence-initial filler openers (and re-capitalize),
 - drop trailing chatbot scaffolding lines,
 - drop filler/ranking praise leads ("Great catch, ...", "Nice find. ..."),
+- drop empty qualifiers ("actual", "actually"),
 - tighten a few verbose phrasings.
 
 Code is never touched: fenced ```blocks``` and `inline code` pass through
@@ -32,7 +33,7 @@ _OPENERS = (
     r"|I noticed that|I wanted to point out that"
     r"|I want to (?:point out|note|mention|flag) that|Please note that"
     r"|Just to (?:note|mention)|Worth noting,?|Note that"
-    r"|Personally|Honestly|Frankly|Quite frankly|To be honest"
+    r"|Actually|Personally|Honestly|Frankly|Quite frankly|To be honest"
     r"|In my (?:honest )?opinion|IMO|IMHO|If you ask me"
     r"|At the end of the day|Generally speaking|Now,? more than ever"
     r"|Furthermore|Moreover|Additionally|Consequently|Nevertheless|Indeed)"
@@ -82,6 +83,25 @@ _THANK_BOT_LEAD_RE = re.compile(r"(^|\n)[ \t]*" + _THANK_BOT + r"[ \t,!.?]*(\w)"
 _THANK_BOT_LINE_RE = re.compile(r"(^|\n)[ \t]*" + _THANK_BOT + r"[ \t,!.?]*(?=\n|$)", re.IGNORECASE)
 _APOLOGY_LEAD_RE = re.compile(r"(^|\n)[ \t]*" + _APOLOGIES + r"[ \t,!.?]*(\w)", re.IGNORECASE)
 _APOLOGY_LINE_RE = re.compile(r"(^|\n)[ \t]*" + _APOLOGIES + r"[ \t,!.?]*(?=\n|$)", re.IGNORECASE)
+# Sentence-initial "Actually," is handled by the opener list; these cover the
+# mid-sentence and trailing uses. The adjective is only dropped after a
+# determiner that doesn't inflect, so "an actual bug" is left to the prompt.
+_ACTUALLY_TRAIL_RE = re.compile(
+    r"(?<=\w)[ \t]*,?[ \t]*\bactually\b(?=[ \t]*(?:[.,;:!?)\]]|$|\n))", re.IGNORECASE
+)
+_ACTUALLY_MID_RE = re.compile(r"(?<=\w)[ \t]+actually\b", re.IGNORECASE)
+# "... works. Actually it does." — mid-line sentence starts, which the opener
+# list (anchored to the start of a line) never sees.
+_ACTUALLY_SENTENCE_RE = re.compile(r"([.!?][ \t]+)actually\b[ \t,]*(\w)", re.IGNORECASE)
+# The word after "actual" must be its noun: a verb, conjunction, or preposition
+# there means "the actual" was the noun ("compare the actual to the expected").
+_ACTUAL_ADJ_RE = re.compile(
+    r"\b(the|this|that|these|those|its|their|our|your|my|no|each|any|every|some|all)"
+    r"[ \t]+actual[ \t]+"
+    r"(?!(?:is|was|are|were|be|been|and|or|to|vs\.?|versus|of|in|on|at|for|with"
+    r"|from|than|but|so|because)\b)(?=\w)",
+    re.IGNORECASE,
+)
 _FENCE_RE = re.compile(r"(```[\s\S]*?```)")
 _INLINE_RE = re.compile(r"(`[^`\n]*`)")
 
@@ -105,6 +125,11 @@ def _scrub_prose(s: str) -> str:
     s = _APOLOGY_LEAD_RE.sub(lambda m: m.group(1) + m.group(2).upper(), s)
     # Strip filler openers at the start of the text or a line; recapitalize.
     s = _OPENER_RE.sub(lambda m: m.group(1) + m.group(2).upper(), s)
+    # Drop "actually" (trailing first, so its comma goes with it) and "actual".
+    s = _ACTUALLY_SENTENCE_RE.sub(lambda m: m.group(1) + m.group(2).upper(), s)
+    s = _ACTUALLY_TRAIL_RE.sub("", s)
+    s = _ACTUALLY_MID_RE.sub("", s)
+    s = _ACTUAL_ADJ_RE.sub(lambda m: m.group(1) + " ", s)
     # Safe lexicon replacements: leverage/utilize -> use.
     s = re.sub(r"\butilize\b", "use", s, flags=re.IGNORECASE)
     s = re.sub(r"\butilizes\b", "uses", s, flags=re.IGNORECASE)

--- a/src/klaussy/skills.py
+++ b/src/klaussy/skills.py
@@ -72,6 +72,13 @@ HUMANIZE_BLOCK = "\n".join(
         " the point directly.",
         '- **No chatbot scaffolding.** No "Let me know if...", "Hope this helps",'
         ' "Feel free to...", "Happy to help", "Let me know your thoughts".',
+        '- **Never use "actual" or "actually", and don\'t swap in "real",'
+        ' "really", "genuinely", or "truly".** All of them are empty emphasis:'
+        ' "it actually works" is "it works", "the actual value" is "the value",'
+        ' "real work" is "work". Delete the word. If the sentence needs a'
+        ' contrast, name it ("the value on disk, not the cached one"), and keep'
+        ' "real" only where it draws a distinction the reader can\'t infer'
+        ' ("real user data, not fixtures").',
         '- **Tighten hedges.** "in order to" → "to"; "could potentially"'
         ' → "could"; "may potentially" → "may". Drop stacked'
         " qualifiers.",
@@ -109,6 +116,19 @@ HUMANIZE_BLOCK = "\n".join(
         ' catch", "great find", "excellent point", "the most important issue'
         ' here". Rating a comment against the others is an AI tell and adds'
         " nothing. State the substance and stop.",
+        "- **No \"most people\" claims.** Don't invent a consensus you can't"
+        ' source: "most people expect this", "most developers find this'
+        ' confusing", "everyone does it this way", "nobody reads these logs",'
+        ' "it\'s widely considered best practice". Argue from the code, the'
+        " repo's own conventions, or a linkable source instead, or state it as"
+        ' your own view ("I\'d expect X here").',
+        '- **Never say "nobody asked for this".** Don\'t dismiss work by'
+        " claiming it was unwanted, and don't dress the same move up as"
+        ' "nobody requested this", "this wasn\'t asked for", "out of nowhere",'
+        ' or "why is this here at all". It reads as a swipe at the author and'
+        " says nothing about the code. Name the concrete objection instead:"
+        " the scope it exceeds, the cost it adds, or the requirement it doesn't"
+        ' map to ("this isn\'t in the ticket, should it ship separately?").',
         "- **Don't mirror the thread's tone.** When you reply to an existing"
         " comment, review note, or message, read it for substance but not for"
         " temperature: neutralize any rudeness or bluntness in it before you"

--- a/src/klaussy/templates/skills/humanize/SKILL.md
+++ b/src/klaussy/templates/skills/humanize/SKILL.md
@@ -15,7 +15,7 @@ If `$ARGUMENTS` is empty, humanize the prose the user pasted into the conversati
 ## Steps
 
 1. **Get the prose.** For file targets, Read each file. For pasted text, work with what's in the conversation. If the text is a reply inside a thread (a review comment, a message chain), the surrounding comments are read-only context: take their substance, neutralize their tone in your head, and humanize only your own message. Don't carry the thread's bluntness or rudeness into what you write — see "Don't mirror the thread's tone" above.
-2. **Rewrite by the rules above.** This is the judgment pass: kill filler openers, drop chatbot scaffolding, replace em/en dashes, tighten hedges, vary sentence shape. Only touch prose, never code, identifiers, or anything inside backticks or fences.
+2. **Rewrite by the rules above.** This is the judgment pass: kill filler openers, drop chatbot scaffolding, replace em/en dashes, tighten hedges, cut empty emphasis (*actual*, *actually*, *real*, *really*, *truly*), vary sentence shape. Only touch prose, never code, identifiers, or anything inside backticks or fences.
 3. **Run the deterministic backstop.** klaussy ships a code-preserving scrubber that guarantees the high-confidence tells are gone regardless of the rewrite. This is the post-processing step, always run it last:
    - **Files:** `klaussy humanize <file>... --write` (rewrites in place; prints which files changed).
    - **Pasted text:** pipe the rewritten text into `klaussy humanize` on stdin and use its output (on macOS/Linux, e.g. `printf '%s' "$text" | klaussy humanize`; on Windows use the shell's own piping — the point is stdin in, humanized text out).
@@ -24,7 +24,9 @@ If `$ARGUMENTS` is empty, humanize the prose the user pasted into the conversati
 
 ## Rules
 
-- The deterministic scrubber is a conservative subset (dashes, a fixed set of openers/scaffolding, a few hedges). Your rewrite does the broader work the scrubber can't; the scrubber then guarantees the conservative tells. Run both, not just one.
+- The deterministic scrubber is a conservative subset (dashes, a fixed set of openers/scaffolding, a few hedges, *actual*/*actually*). Your rewrite does the broader work the scrubber can't; the scrubber then guarantees the conservative tells. Run both, not just one.
+- Appeals to consensus ("most people expect...", "everyone does it this way") are a rewrite-only fix too. Don't just soften them into "many teams" — either cite what the claim rests on (the code, a repo convention, a link) or make it your own view. Dropping the claim entirely is fine when the sentence stands without it.
+- *real*, *really*, *genuinely*, and *truly* are the rewrite's job, not the scrubber's — it leaves them alone because "real user data" sometimes contrasts with fixtures. Cut them where they only add emphasis ("real work" is "work"), keep them where they carry that contrast.
 - Preserve the decision and its rationale; never reverse, add, or invent meaning. Humanizing is mostly a tone/style edit, but brevity may drop low-value detail (explanatory parentheticals, restated identifiers, narration the diff already shows). Keep the load-bearing facts, cut what the reader can reconstruct (see "Cut detail, not just words" above).
 - Never reword code, identifiers, fenced ```blocks```, or `inline code`. The scrubber already skips them; you must too.
 - Don't "improve" prose beyond removing AI tells, keeping it civil (see "Don't let trimming tip into terse" above), and tightening length (see "Be short, then cut more") unless the user asks. Match the surrounding voice — a slightly blunt author stays slightly blunt, you only stop the trim from making them ruder.

--- a/src/klaussy/templates/skills/review/SKILL.md
+++ b/src/klaussy/templates/skills/review/SKILL.md
@@ -82,7 +82,7 @@ You are a senior/principal-level engineer reviewing a pull request. Treat this a
 - If behavior is unclear, treat that as a problem.
 - Prefer concrete fixes over vague advice.
 - **Precision over recall.** Default to *not* reporting. If no finding is one a competent author would clearly want to fix, return an empty review and say so — an empty review is a valid, good outcome, not a failure. Do not invent findings or pad to look thorough.
-- **Every finding must name a concrete trigger.** State the specific input, state, or execution path that makes it go wrong. If you cannot describe how the problem is actually reached, you have not proven it — drop it.
+- **Every finding must name a concrete trigger.** State the specific input, state, or execution path that makes it go wrong. If you cannot describe how the problem is reached, you have not proven it — drop it.
 - **Don't self-assign confidence scores.** A number you make up is noise; the trigger path above is the real evidence. Lead with the evidence, not a percentage.
 
 ### What to look for (in order of priority):
@@ -176,7 +176,7 @@ Before synthesizing, validate every finding from the sub-agents. The rubric for 
 3. **Argue the author's side, then refute it.** For each finding, write the strongest one-line case that it is *not* a real problem (the input can't occur, a caller already guards it, the framework handles it). Then either refute that case with specific code evidence, or — if you can't — drop the finding as a likely false positive. A finding you can't defend against its own counterargument doesn't ship.
 4. **Determine if the finding is still valid** given the full context. Common reasons a finding is invalid:
    - The issue is already handled elsewhere (e.g., validation happens in a caller, error is caught upstream).
-   - The code path cannot actually be reached in the way the finding assumes.
+   - The code path cannot be reached in the way the finding assumes.
    - The finding misreads the logic due to missing surrounding context.
    - The concern is about code that was not changed in this PR and is out of scope.
    - A dependency or framework already guarantees the behavior the finding questions.

--- a/src/klaussy/templates/skills/review/sub-agents.md
+++ b/src/klaussy/templates/skills/review/sub-agents.md
@@ -6,7 +6,7 @@ Loaded by `{{REPO}}-review` Phase 2 when the diff is ≥ 150 lines. The sub-agen
 
 For each selected sub-agent, build the prompt body as:
 
-1. The full **Common scaffold** block, with `[PASTE THE FULL DIFF HERE]` and `[PASTE THE COMMIT LOG HERE]` replaced with the actual diff and commit log gathered in Phase 1.
+1. The full **Common scaffold** block, with `[PASTE THE FULL DIFF HERE]` and `[PASTE THE COMMIT LOG HERE]` replaced with the diff and commit log gathered in Phase 1.
 2. The sub-agent's `## Lens` section verbatim.
 3. The sub-agent's `## Additional rules` section (if it has one).
 
@@ -150,7 +150,7 @@ For each finding, be specific about the failure mode (the exact input or state t
 - Were tests added or updated for the changes?
 - Are edge cases covered?
 - Are failure paths tested?
-- Do tests actually assert meaningful behavior (not just "doesn't crash")?
+- Do tests assert meaningful behavior (not just "doesn't crash")?
 - Are mocks/stubs appropriate, or do they hide real behavior?
 ```
 
@@ -280,7 +280,7 @@ quote the doc section (or note its absence) and explain what's missing and why i
 matters.
 
 ### Decision quality
-- **Problem/context is concrete** — the doc states the actual problem and forces at
+- **Problem/context is concrete** — the doc states the problem and forces at
   play, not a vague preamble. Flag a problem statement so generic it could precede
   any decision.
 - **The decision is explicit** — there is an unambiguous "we will do X" outcome, not
@@ -303,7 +303,7 @@ matters.
   ideally the old one is marked superseded). Flag a decision that silently contradicts
   an existing ADR in the repo without superseding it.
 - **Code-vs-decision consistency** — if the same PR also changes code, verify the code
-  actually implements the decided design. Flag drift between "we will do X" and code
+  implements the decided design. Flag drift between "we will do X" and code
   that does Y. This is the highest-value check a PR-time review can make that a
   standalone doc review cannot.
 
@@ -316,7 +316,7 @@ matters.
 - **Sprint**: only one option; only short-term effects considered.
 - **Fairy Tale**: shallow justification, pros only, no cons.
 - **Ghost architecture**: code makes an architecturally significant choice that the doc
-  doesn't actually record (or vice versa).
+  doesn't record (or vice versa).
 - **Rubber-stamp**: a "decision" written after the fact to legitimize code already
   merged, with no real evaluation.
 
@@ -355,7 +355,7 @@ For EACH finding, apply this rubric. Read whatever files you need — the refere
 1. Read the full file at the finding's location, not just the diff hunk.
 2. Trace the code path: follow function calls, imports, type definitions, and control flow across files.
 3. Argue the author's side, then refute it. Write the strongest one-line case that this is NOT a real problem (the input can't occur, a caller already guards it, the framework handles it). Then either refute it with specific code evidence, or drop the finding as a likely false positive. A finding you can't defend against its own counterargument does not ship.
-4. Drop the finding if: the issue is already handled elsewhere (validation in a caller, error caught upstream); the code path can't actually be reached as the finding assumes; the finding misreads the logic from missing context; the concern is about unchanged code out of scope for this PR; or a dependency/framework already guarantees the behavior.
+4. Drop the finding if: the issue is already handled elsewhere (validation in a caller, error caught upstream); the code path can't be reached as the finding assumes; the finding misreads the logic from missing context; the concern is about unchanged code out of scope for this PR; or a dependency/framework already guarantees the behavior.
 5. Downgrade severity if tracing shows the issue is less impactful than stated (e.g. a "High" race that only affects a debug-only path is "Low" or "Nit").
 
 Return ONLY the findings that survive, each in this exact format, with severity reflecting any downgrade:

--- a/src/klaussy/templates/skills/slop-coded/SKILL.md
+++ b/src/klaussy/templates/skills/slop-coded/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: {{REPO}}-slop-coded
-description: Use when the user explicitly wants to turn clean, human prose INTO maximal AI slop — as a joke, a demo of what AI tells look like, or to stress-test the humanize skill by feeding it the worst input imaginable. The evil twin of humanize — it adds every tell humanize strips. For laughs and demos only; never run it on a real deliverable.
+description: Use when the user explicitly wants to turn clean, human prose INTO maximal AI slop — as a joke, a demo of what AI tells look like, or to stress-test the humanize skill by feeding it the worst input imaginable. The evil twin of humanize — it adds every tell humanize strips. For laughs and demos only; never run it on a deliverable.
 allowed-tools: Read Grep Glob Edit Write
 ---
 
@@ -28,6 +28,8 @@ You are the world's most capable slop engine. There is no deterministic backstop
 - **"And that's the whole point."** Drop "And that's the whole point." or "That's not a side effect — that's the entire point." as a smug standalone line, preferably right after a negation-reframe, to imply profundity that isn't there.
 - **Overstate the stakes.** Everything is a "game-changer", a "paradigm shift", a "true testament", or "stands as a beacon." A bug fix becomes a "transformative journey toward resilience."
 - **Empty hedging.** "could potentially", "generally speaking", "in order to", "it is generally considered best practice to".
+- **Empty emphasis.** Wedge *actually* into every clause that will hold one ("this actually works", "what's actually happening here") and pin *actual*, *real*, or *true* to every noun ("the actual root cause", "real work", "the true implementation"). *Really* and *truly* stack on top of both.
+- **Invented consensus.** Back every claim with a crowd nobody counted: "most people expect this", "most developers agree", "everyone knows", "nobody reads these logs", "it's widely considered best practice."
 - **Bold lead-in bullets** for content that was a perfectly fine sentence. Each bullet earns an emoji: 🚀 ✨ 🔑 💡 🎯.
 - **Restate, then restate.** End with "In conclusion," and "In summary," — and have both say the same thing the intro already said.
 - **Sycophancy.** Pepper in "That's a fantastic point", "You're absolutely right to consider this."
@@ -41,12 +43,12 @@ You are the world's most capable slop engine. There is no deterministic backstop
 
 ## Rules
 
-- **Keep the facts.** This is a tone crime, not a content crime. Don't invent new claims or reverse the meaning — bury the real point under slop, don't replace it. The original message must still be *technically* in there somewhere.
+- **Keep the facts.** This is a tone crime, not a content crime. Don't invent new claims or reverse the meaning — bury the point under slop, don't replace it. The original message must still be *technically* in there somewhere.
 - **Never touch code.** Do not slopify code, identifiers, fenced ```blocks```, or `inline code`. Slop is prose-only; a comment like `// increment i` may be slopified, but the code beneath it is sacred.
-- **Don't slopify real work.** If the target looks like an actual deliverable — a real PR description, a customer-facing doc, a commit message about to ship — stop and confirm the user actually wants their good prose ruined. This skill is for jokes and demos.
+- **Don't slopify anything that ships.** If the target looks like a deliverable — a PR description, a customer-facing doc, a commit message about to land — stop and confirm the user wants their good prose ruined. This skill is for jokes and demos.
 - It pairs beautifully with humanize: slopify something, then run `{{REPO}}-humanize` on it to watch the scrubber undo your crimes.
 
 ## When NOT to use
 
 - The user wants prose that reads *better* or more human — that's the humanize skill, the exact opposite of this one.
-- The user wants real code, docs, or a review. Don't slop a serious request.
+- The user wants usable code, docs, or a review. Don't slop a serious request.

--- a/tests/test_humanize_openers.py
+++ b/tests/test_humanize_openers.py
@@ -68,3 +68,48 @@ class TestExtendedScrubber:
         assert humanize("Thanks @dependabot! We should merge this.") == "We should merge this."
         assert humanize("Thank you for the review, @codecov-bot!") == ""
         assert humanize("Thanks, bot.") == ""
+
+
+class TestActuallyStripping:
+    def test_opener_is_stripped_and_recapitalized(self):
+        assert humanize("Actually, this races on startup.") == "This races on startup."
+        assert humanize("Actually the lock is wrong.") == "The lock is wrong."
+
+    def test_second_sentence_opener_is_stripped(self):
+        assert humanize("It works. Actually it does.") == "It works. It does."
+        assert humanize("Fine. Actually, the lock is wrong.") == "Fine. The lock is wrong."
+
+    def test_mid_sentence_adverb_is_dropped(self):
+        assert humanize("The retry actually fires twice.") == "The retry fires twice."
+        assert humanize("We actually need both branches.") == "We need both branches."
+
+    def test_trailing_adverb_takes_its_comma(self):
+        assert humanize("This works, actually.") == "This works."
+        assert humanize("The cache is stale actually!") == "The cache is stale!"
+
+    def test_adjective_is_dropped_after_a_determiner(self):
+        assert humanize("Read the actual query.") == "Read the query."
+        assert humanize("This is their actual root cause.") == "This is their root cause."
+
+    def test_actual_as_a_noun_is_left_alone(self):
+        # "the actual" is the noun in test/review prose, not a modifier.
+        assert humanize("Compare the actual to the expected.") == (
+            "Compare the actual to the expected."
+        )
+        assert (
+            humanize("The actual is 3, the expected is 4.") == "The actual is 3, the expected is 4."
+        )
+        assert humanize("Check the actual vs expected output.") == (
+            "Check the actual vs expected output."
+        )
+
+    def test_adjective_left_alone_where_dropping_it_would_break_grammar(self):
+        # "an actual bug" would become "an bug" — left to the prompt-side rule.
+        assert humanize("That is an actual bug.") == "That is an actual bug."
+
+    def test_no_midword_clipping(self):
+        assert humanize("The actuals feed the report.") == "The actuals feed the report."
+        assert humanize("Check factual claims.") == "Check factual claims."
+
+    def test_code_is_preserved(self):
+        assert humanize("Call `get_actual()` here.") == "Call `get_actual()` here."


### PR DESCRIPTION
## Summary

Release 0.19.3. Adds three rules to the shared humanize block that every prose-output skill inherits, and teaches the deterministic scrubber to enforce the first one.

- **No `actual`/`actually`**, and no swapping in `real`/`really`/`genuinely`/`truly`. All of them are empty emphasis: "it actually works" is "it works", "real work" is "work".
- **No invented consensus** — `most people expect this`, `everyone does it this way`, `it's widely considered best practice`. Argue from the code, a repo convention, or a linkable source, or state it as your own view.
- **No `nobody asked for this`** or its paraphrases. It reads as a swipe at the author and says nothing about the code; name the scope, cost, or requirement instead.

The scrubber handles `actual`/`actually` deterministically. `real` stays prompt-side, since deleting it flips meaning ("real user data, not fixtures"), and a consensus claim needs the sentence rewritten, not a word deleted.

## Changes

- `src/klaussy/skills.py` — three new bullets in `HUMANIZE_BLOCK`.
- `src/klaussy/humanize.py` — `Actually` joins the opener list; new rules drop the adverb mid-sentence, at a sentence start, and trailing with its comma. The adjective goes only after a determiner that doesn't inflect ("an actual bug" never becomes "an bug") and only when the next word can head a noun phrase ("compare the actual to the expected" is left intact).
- `src/klaussy/templates/skills/humanize/SKILL.md` — the judgment pass names the new tells, plus which ones the scrubber won't do for you.
- `src/klaussy/templates/skills/slop-coded/SKILL.md` — matching tells, so the evil twin still produces what humanize strips.
- `src/klaussy/templates/skills/review/*` — drop their own uses of the banned words.
- Version bump, changelog, README.

## Test Plan

- `pytest` — 632 passed, 15 skipped. New `TestActuallyStripping` covers each stripping path plus the non-cases: `actuals`, `factual`, `` `get_actual()` ``, "an actual bug", and "the actual" used as a noun.
- `ruff check` / `ruff format --check` clean.
- The pre-commit guard caught the noun case ("compare the actual to the expected" became "compare the to the expected") before the first commit landed; the lookahead fix and its test came from that finding.

## Checklist

- [x] Tests pass
- [x] Lint and format clean
- [x] Changelog updated
- [ ] `examples/fastapi` and `examples/httpx` still carry the 0.19.2 skill output — regeneration deferred to a later release, noted in the changelog.

After merge: tag `v0.19.3` on main and push it to trigger the PyPI release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
