### PR TITLE
Release 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
-## [Unreleased]
+## [0.20.0] - 2026-07-26
 
 ### Added
 
@@ -33,6 +33,14 @@ before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
   hook schema has no per-OS override; doing the resolution in the launcher keeps
   one command string working in sh, cmd, and PowerShell alike. Kimi is ✅/✅ in
   the README cross-platform matrix.
+
+### Documentation
+
+- README: Kimi in the hero line, the supported-agents list and the cross-platform
+  table, and the agent count moved from nine to ten. The Codex row is now labelled
+  **Codex CLI (OpenAI)** — klaussy always supported OpenAI's agent but never said
+  so — alongside a note that these targets are agent tools rather than model
+  vendors, so GPT users reach klaussy through Codex, aider, or opencode.
 
 ## [0.19.3] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ toolkit.init(repo=".", agents=["claude", "cursor"])
 
 ## 📜 Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.19.3** (the humanize rules now ban empty emphasis like `actual`/`really`, invented consensus like `most people expect this`, and swipes at the author like `nobody asked for this`).
+See [CHANGELOG.md](CHANGELOG.md) for the full release history. The latest release is **v0.20.0** (Kimi Code CLI joins as a tenth agent backend, and `klaussy-hook` gains `--repo-relative` so a globally-configured hook resolves whichever repo the session is in).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.19.3"
+version = "0.20.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), opencode, and Kimi Code CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.19.3"
+__version__ = "0.20.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read


### PR DESCRIPTION
## Summary

Release 0.20.0 — cuts the version for the Kimi Code CLI backend merged in #27. Minor rather than patch: the README's agent count is a public claim that moved nine → ten, and `klaussy-hook --repo-relative` is new surface area other backends could use later.

## Changes

- `pyproject.toml` and `src/klaussy/__init__.py` → `0.20.0` (both, so the `.klaussy-version` scaffold marker matches the published package)
- `CHANGELOG.md`: `[Unreleased]` → `[0.20.0] - 2026-07-26`, plus a Documentation entry for the README changes that shipped with #27 (Kimi listed, Codex relabelled "Codex CLI (OpenAI)", agent-vs-model note)
- README "latest release" line updated

## Test Plan

- [x] Tests pass locally — `656 passed, 15 skipped`; `ruff check src/ tests/` clean
- [x] Manually verified — `pyproject` and `klaussy.__version__` both report `0.20.0`

No code changes in this PR beyond the version constants.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality — n/a, version bump only
- [x] Documentation updated if needed

**After merge:** pushing the `v0.20.0` tag is what publishes to PyPI (`release.yml` runs on `refs/tags/v*` only). Tell me when this is merged and I'll push the tag, or push it yourself with `git tag v0.20.0 <merge-sha> && git push origin v0.20.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
