### PR TITLE
docs(readme): use a live PyPI downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Klaussy-Agents
 
 [![PyPI version](https://img.shields.io/pypi/v/klaussy-agents.svg)](https://pypi.org/project/klaussy-agents/)
-[![PyPI downloads](https://img.shields.io/badge/downloads-2.3K%2B%2Fmonth-blue?logo=pypi&logoColor=white)](https://pypi.org/project/klaussy-agents/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/klaussy-agents?logo=pypi&logoColor=white&color=blue&label=downloads)](https://pypistats.org/packages/klaussy-agents)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/steph-dove/klaussy-agents?style=flat&logo=github&label=Stars&color=blue)](https://github.com/steph-dove/klaussy-agents)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,10 @@ klaussy-mcp = "klaussy.mcp_server:main"
 klaussy-hook = "klaussy._hooklauncher:main"
 
 [project.optional-dependencies]
-mcp = ["mcp[cli]>=1.0.0"]
-dev = ["pytest>=7.0", "ruff>=0.4.0", "mcp[cli]>=1.0.0"]
+# mcp 2.0.0 renamed FastMCP to MCPServer and dropped mcp.server.fastmcp, which
+# mcp_server.py still imports. Capped until that migration lands.
+mcp = ["mcp[cli]>=1.0.0,<2"]
+dev = ["pytest>=7.0", "ruff>=0.4.0", "mcp[cli]>=1.0.0,<2"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
The badge was a hardcoded shields "2.3K+/month" that had drifted overstated — actual last-30-days is 1,937. Switch to shields' pypi/dm endpoint so it tracks the real mirrors-excluded number instead of going stale, and point the link at pypistats.