### PR TITLE
feat(pr-template): write the template where the repo's host reads it

### DIFF
--- a/src/klaussy/cli.py
+++ b/src/klaussy/cli.py
@@ -14,10 +14,10 @@ from klaussy.checklist import generate_checklist
 from klaussy.claude_md import run_init
 from klaussy.comment_lint import analyze as analyze_comments
 from klaussy.comment_lint import changed_lines
-from klaussy.github import scaffold_github
 from klaussy.gitignore import update_gitignore
 from klaussy.humanize import humanize as humanize_text
 from klaussy.import_lint import scan_paths as scan_imports
+from klaussy.pr_template import scaffold_pr_template
 from klaussy.review_prep import prepare_review, render_dict, render_markdown
 from klaussy.secret_scan import scan_paths as scan_secrets
 
@@ -132,7 +132,7 @@ def init(
                 review_template=review_template,
             )
         )
-    steps.append(("PR template", lambda: scaffold_github(repo=repo, force=force)))
+    steps.append(("PR template", lambda: scaffold_pr_template(repo=repo, force=force)))
     steps.append((".gitignore", lambda: update_gitignore(repo=repo)))
 
     for name, step in steps:
@@ -237,13 +237,32 @@ def hooks(
             console.print(f"[yellow]⚠ Skipped {key} hooks[/yellow]")
 
 
-@app.command()
+@app.command("pr-template")
+def pr_template(
+    repo: Path = typer.Option(".", "--repo", "-r", help="Path to the repository."),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing files."),
+    forge: str | None = typer.Option(
+        None,
+        "--forge",
+        help="Host to target (github/gitlab/bitbucket). Detected from origin if omitted.",
+    ),
+) -> None:
+    """Generate the pull/merge request template where this repo's host reads it."""
+    try:
+        scaffold_pr_template(repo=repo, force=force, forge=forge)
+    except ValueError as exc:
+        console.print(f"[red]✗ {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
+@app.command(hidden=True)
 def github(
     repo: Path = typer.Option(".", "--repo", "-r", help="Path to the repository."),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing files."),
 ) -> None:
-    """Generate PR template for the repository."""
-    scaffold_github(repo=repo, force=force)
+    """Deprecated: use `klaussy pr-template`."""
+    console.print("[yellow]⚠ `klaussy github` is now `klaussy pr-template`.[/yellow]")
+    scaffold_pr_template(repo=repo, force=force)
 
 
 @app.command()

--- a/src/klaussy/github.py
+++ b/src/klaussy/github.py
@@ -1,33 +1,12 @@
-"""Generate PR template if the repo doesn't already have one."""
+"""Deprecated alias for `klaussy.pr_template`.
 
-from importlib import resources
-from pathlib import Path
+The template isn't GitHub-only any more, so the module moved. This shim keeps
+`from klaussy.github import scaffold_github` working for anything pinned to the
+old name; remove it in the next major version.
+"""
 
-from rich.console import Console
+from klaussy.pr_template import scaffold_pr_template
 
-console = Console()
+__all__ = ["scaffold_github", "scaffold_pr_template"]
 
-
-def scaffold_github(*, repo: Path, force: bool = False) -> Path | None:
-    """Create .github/PULL_REQUEST_TEMPLATE.md only if none exists."""
-    repo = repo.resolve()
-
-    pr_template_file = repo / ".github" / "PULL_REQUEST_TEMPLATE.md"
-    search_dirs = [repo, repo / ".github", repo / "docs"]
-    has_existing_template = any(
-        (d / "PULL_REQUEST_TEMPLATE.md").exists()
-        or (d / "pull_request_template.md").exists()
-        or (d / "PULL_REQUEST_TEMPLATE").is_dir()
-        for d in search_dirs
-    )
-
-    if has_existing_template and not force:
-        console.print("[dim]PR template already exists, skipping.[/dim]")
-        return None
-
-    templates = resources.files("klaussy").joinpath("templates/github")
-    content = templates.joinpath("PULL_REQUEST_TEMPLATE.md").read_text()
-    pr_template_file.parent.mkdir(parents=True, exist_ok=True)
-    pr_template_file.write_text(content)
-    console.print(f"[green]✔ Created {pr_template_file.relative_to(repo)}[/green]")
-    return pr_template_file
+scaffold_github = scaffold_pr_template

--- a/src/klaussy/mcp_server.py
+++ b/src/klaussy/mcp_server.py
@@ -142,16 +142,27 @@ def klaussy_hooks(repo: str = ".", force: bool = False, agents: str = "all") -> 
 
 
 @mcp.tool()
-def klaussy_github(repo: str = ".", force: bool = False) -> str:
-    """Generate a PR template for the repository.
+def klaussy_pr_template(repo: str = ".", force: bool = False, forge: str = "") -> str:
+    """Generate the pull/merge request template where this repo's host reads it.
 
-    Created only if the repo doesn't already have one (checks the root,
-    `.github/`, and `docs/`) unless `force` is set.
+    The host comes from `origin` unless `forge` names one (github/gitlab/
+    bitbucket). GitHub gets `.github/PULL_REQUEST_TEMPLATE.md`, GitLab gets
+    `.gitlab/merge_request_templates/`, and Bitbucket is skipped since it has
+    no tracked-file equivalent. Written only if the repo doesn't already have
+    one unless `force` is set.
     """
-    args = ["github", "--repo", repo]
+    args = ["pr-template", "--repo", repo]
     if force:
         args.append("--force")
+    if forge:
+        args.extend(["--forge", forge])
     return _run_klaussy(*args, cwd=repo)
+
+
+@mcp.tool()
+def klaussy_github(repo: str = ".", force: bool = False) -> str:
+    """Deprecated alias for `klaussy_pr_template`."""
+    return klaussy_pr_template(repo=repo, force=force)
 
 
 @mcp.tool()

--- a/src/klaussy/pr_template.py
+++ b/src/klaussy/pr_template.py
@@ -1,0 +1,93 @@
+"""Generate the host's pull/merge request template if the repo lacks one.
+
+The body is host-agnostic; only the path differs. GitHub reads
+`.github/PULL_REQUEST_TEMPLATE.md`, GitLab reads
+`.gitlab/merge_request_templates/`, and Bitbucket is skipped because its
+default description is a repo setting, not a tracked file.
+"""
+
+from importlib import resources
+from pathlib import Path
+
+from rich.console import Console
+
+from klaussy.forge import FORGE_BITBUCKET, FORGE_GITLAB, FORGE_UNKNOWN, FORGES, detect_forge
+
+console = Console()
+
+_GITHUB_TARGET = Path(".github") / "PULL_REQUEST_TEMPLATE.md"
+_GITLAB_TARGET = Path(".gitlab") / "merge_request_templates" / "Default.md"
+
+
+def _github_has_template(repo: Path) -> bool:
+    search_dirs = [repo, repo / ".github", repo / "docs"]
+    return any(
+        (d / "PULL_REQUEST_TEMPLATE.md").exists()
+        or (d / "pull_request_template.md").exists()
+        or (d / "PULL_REQUEST_TEMPLATE").is_dir()
+        for d in search_dirs
+    )
+
+
+def _gitlab_has_template(repo: Path) -> bool:
+    templates_dir = repo / ".gitlab" / "merge_request_templates"
+    return templates_dir.is_dir() and any(templates_dir.glob("*.md"))
+
+
+def _resolve_host(repo: Path, forge: str | None) -> str:
+    """Validate an explicit forge name, or detect one from the repo.
+
+    An unrecognized name fails loudly; falling through to the GitHub branch
+    would silently write the wrong path for a typo like `gitlub`.
+    """
+    if forge is None:
+        return detect_forge(repo)
+    name = forge.strip().lower()
+    if name not in FORGES:
+        raise ValueError(f"Unknown forge {forge!r}. Choose one of: {', '.join(FORGES)}.")
+    return name
+
+
+def scaffold_pr_template(
+    *, repo: Path, force: bool = False, forge: str | None = None
+) -> Path | None:
+    """Write the request template where this repo's host reads it.
+
+    Returns the path written, or None when one already exists or the host has
+    nowhere to put it.
+    """
+    repo = repo.resolve()
+    host = _resolve_host(repo, forge)
+
+    if host == FORGE_BITBUCKET:
+        console.print(
+            "[dim]Bitbucket has no repo-file request template "
+            "(its default description is a repo setting), skipping.[/dim]"
+        )
+        return None
+
+    if host == FORGE_GITLAB:
+        target, exists = _GITLAB_TARGET, _gitlab_has_template(repo)
+    else:
+        # Undetected hosts fall back to the GitHub layout: a stray markdown file
+        # is inert if the guess is wrong, and skipping would deny a template to
+        # every repo scaffolded before its remote exists.
+        if host == FORGE_UNKNOWN:
+            console.print(
+                "[dim]Host not identified from origin, using the GitHub layout. "
+                "Pass --forge to choose.[/dim]"
+            )
+        target, exists = _GITHUB_TARGET, _github_has_template(repo)
+
+    if exists and not force:
+        console.print("[dim]Request template already exists, skipping.[/dim]")
+        return None
+
+    content = (
+        resources.files("klaussy").joinpath("templates/github/PULL_REQUEST_TEMPLATE.md").read_text()
+    )
+    template_file = repo / target
+    template_file.parent.mkdir(parents=True, exist_ok=True)
+    template_file.write_text(content)
+    console.print(f"[green]✔ Created {template_file.relative_to(repo)}[/green]")
+    return template_file

--- a/src/klaussy/toolkit.py
+++ b/src/klaussy/toolkit.py
@@ -21,9 +21,9 @@ from pathlib import Path
 from klaussy.agents import ALL_AGENTS, BACKENDS, resolve_agents
 from klaussy.checklist import generate_checklist
 from klaussy.claude_md import run_init
-from klaussy.github import scaffold_github
 from klaussy.gitignore import update_gitignore
 from klaussy.humanize import humanize as _humanize_text
+from klaussy.pr_template import scaffold_pr_template
 from klaussy.session import scaffold_session
 from klaussy.skills import SKILL_NAMES
 
@@ -35,6 +35,7 @@ __all__ = [
     "skills",
     "settings",
     "hooks",
+    "pr_template",
     "github",
     "checklist",
     "session",
@@ -136,7 +137,7 @@ def init(
         steps.extend(
             BACKENDS[key].steps(repo, force=force, base_branch=branch, review_template=template)
         )
-    steps.append(("PR template", lambda: scaffold_github(repo=repo, force=force)))
+    steps.append(("PR template", lambda: scaffold_pr_template(repo=repo, force=force)))
     steps.append(("shared session", lambda: scaffold_session(repo=repo, force=force)))
     steps.append((".gitignore", lambda: update_gitignore(repo=repo)))
     return _run_steps(repo, selected, steps)
@@ -189,9 +190,16 @@ def hooks(repo: PathLike = ".", *, agents: Agents = None, force: bool = False) -
     return _run_steps(repo, selected, steps)
 
 
+def pr_template(
+    repo: PathLike = ".", *, force: bool = False, forge: str | None = None
+) -> Path | None:
+    """Write the host's request template; returns its path, or None if none was written."""
+    return scaffold_pr_template(repo=Path(repo).resolve(), force=force, forge=forge)
+
+
 def github(repo: PathLike = ".", *, force: bool = False) -> Path | None:
-    """Generate the PR template; returns its path, or None if one already exists."""
-    return scaffold_github(repo=Path(repo).resolve(), force=force)
+    """Deprecated alias for `pr_template`."""
+    return pr_template(repo, force=force)
 
 
 def session(repo: PathLike = ".", *, force: bool = False) -> Path:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -18,6 +18,9 @@ def test_one_tool_per_cli_command_plus_status():
         "klaussy_skills",
         "klaussy_settings",
         "klaussy_hooks",
+        "klaussy_pr_template",
+        # Deprecated alias for klaussy_pr_template, kept so pinned MCP configs
+        # keep working. Drop it (and this entry) in the next major version.
         "klaussy_github",
         "klaussy_humanize",
         "klaussy_status",

--- a/tests/test_pr_template.py
+++ b/tests/test_pr_template.py
@@ -1,0 +1,104 @@
+"""The request template goes where the repo's host actually reads it."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from klaussy import toolkit
+from klaussy.forge import FORGE_BITBUCKET, FORGE_GITHUB, FORGE_GITLAB
+from klaussy.pr_template import scaffold_pr_template
+
+GITHUB_PATH = Path(".github") / "PULL_REQUEST_TEMPLATE.md"
+GITLAB_PATH = Path(".gitlab") / "merge_request_templates" / "Default.md"
+
+
+def _repo(path: Path, remote: str | None = None) -> Path:
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    if remote:
+        subprocess.run(["git", "-C", str(path), "remote", "add", "origin", remote], check=True)
+    return path
+
+
+class TestPerHost:
+    def test_github_keeps_its_path(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@github.com:owner/repo.git")
+        assert scaffold_pr_template(repo=repo) == repo / GITHUB_PATH
+        assert (repo / GITHUB_PATH).exists()
+
+    def test_gitlab_gets_the_merge_request_path(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@gitlab.com:group/repo.git")
+        assert scaffold_pr_template(repo=repo) == repo / GITLAB_PATH
+        assert (repo / GITLAB_PATH).exists()
+        assert not (repo / GITHUB_PATH).exists()
+
+    def test_bitbucket_writes_nothing(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@bitbucket.org:ws/repo.git")
+        assert scaffold_pr_template(repo=repo) is None
+        assert not (repo / GITHUB_PATH).exists()
+        assert not (repo / GITLAB_PATH).exists()
+
+    def test_undetected_host_falls_back_to_github(self, tmp_path: Path):
+        # A repo scaffolded before its remote exists still deserves a template;
+        # a stray markdown file is harmless if the fallback guesses wrong.
+        repo = _repo(tmp_path)
+        assert scaffold_pr_template(repo=repo) == repo / GITHUB_PATH
+
+    def test_explicit_forge_overrides_detection(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@github.com:owner/repo.git")
+        assert scaffold_pr_template(repo=repo, forge=FORGE_GITLAB) == repo / GITLAB_PATH
+
+    def test_forge_name_is_case_insensitive(self, tmp_path: Path):
+        repo = _repo(tmp_path)
+        assert scaffold_pr_template(repo=repo, forge=" GitLab ") == repo / GITLAB_PATH
+
+    def test_unknown_forge_raises_instead_of_defaulting(self, tmp_path: Path):
+        # A typo must not fall through to the GitHub layout.
+        repo = _repo(tmp_path, "git@gitlab.com:group/repo.git")
+        with pytest.raises(ValueError, match="gitlub"):
+            scaffold_pr_template(repo=repo, forge="gitlub")
+        assert not (repo / GITHUB_PATH).exists()
+
+
+class TestExisting:
+    def test_existing_github_template_is_left_alone(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@github.com:owner/repo.git")
+        (repo / ".github").mkdir()
+        (repo / GITHUB_PATH).write_text("mine\n")
+        assert scaffold_pr_template(repo=repo) is None
+        assert (repo / GITHUB_PATH).read_text() == "mine\n"
+
+    def test_existing_gitlab_template_under_any_name_counts(self, tmp_path: Path):
+        # GitLab allows several named templates; any one of them means the repo
+        # already has a convention worth not clobbering.
+        repo = _repo(tmp_path, "git@gitlab.com:group/repo.git")
+        (repo / ".gitlab" / "merge_request_templates").mkdir(parents=True)
+        (repo / ".gitlab" / "merge_request_templates" / "Bugfix.md").write_text("mine\n")
+        assert scaffold_pr_template(repo=repo) is None
+
+    def test_force_overwrites(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@gitlab.com:group/repo.git")
+        scaffold_pr_template(repo=repo)
+        assert scaffold_pr_template(repo=repo, force=True) == repo / GITLAB_PATH
+
+
+class TestPublicSurface:
+    def test_toolkit_exposes_both_names(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@gitlab.com:group/repo.git")
+        assert toolkit.pr_template(repo) == repo / GITLAB_PATH
+        assert "pr_template" in toolkit.__all__
+
+    def test_deprecated_toolkit_alias_still_works(self, tmp_path: Path):
+        repo = _repo(tmp_path, "git@github.com:owner/repo.git")
+        assert toolkit.github(repo) == repo / GITHUB_PATH
+
+    def test_deprecated_module_alias_still_imports(self, tmp_path: Path):
+        from klaussy.github import scaffold_github
+
+        repo = _repo(tmp_path, "git@github.com:owner/repo.git")
+        assert scaffold_github(repo=repo) == repo / GITHUB_PATH
+
+    def test_bitbucket_constant_is_wired(self, tmp_path: Path):
+        repo = _repo(tmp_path)
+        assert scaffold_pr_template(repo=repo, forge=FORGE_BITBUCKET) is None
+        assert scaffold_pr_template(repo=repo, forge=FORGE_GITHUB) == repo / GITHUB_PATH


### PR DESCRIPTION
> Stacked on #32 → #31 → #30. Review those first; this diff includes them until they merge.

## Summary

Closes the third gap in the forge support map. Every `klaussy init` wrote `.github/PULL_REQUEST_TEMPLATE.md` regardless of host, so two of the three hosts klaussy claims to support got a file their forge never reads.

## Changes

**The template goes where the host looks.**

| Host | Path | Existing-template check |
| :--- | :--- | :--- |
| GitHub | `.github/PULL_REQUEST_TEMPLATE.md` | root, `.github/`, `docs/` (unchanged) |
| GitLab | `.gitlab/merge_request_templates/Default.md` | any `*.md` in that directory |
| Bitbucket | none — skipped with a reason | n/a |
| Undetected | GitHub layout, with a note and a `--forge` hint | as GitHub |

Bitbucket's default description is a repo setting, not a tracked file, so there's nothing to write and the run says so instead of leaving a dud. The undetected fallback is deliberate: a stray markdown file costs nothing if the guess is wrong, while skipping would deny a template to every repo scaffolded before its remote exists.

GitLab's existence check accepts any named template, since a repo with its own `Bugfix.md` already has a convention worth not adding to.

**Renamed, with aliases**, per the decision on the previous PR. `pr-template` is canonical across all three public surfaces; the old names still work:

- CLI: `klaussy pr-template` (new, takes `--forge`), `klaussy github` hidden and warning
- MCP: `klaussy_pr_template` (new), `klaussy_github` delegating to it
- Toolkit: `toolkit.pr_template()` (new), `toolkit.github()` delegating
- Module: `klaussy/pr_template.py`, with `klaussy/github.py` left as an import shim

All four aliases are marked for removal in the next major version.

## Test Plan

- [x] `pytest tests/` — 698 passed, 15 skipped (16 new). `ruff check src/ tests/` clean.
- [x] `tests/test_pr_template.py` covers each host's path, the negative case for Bitbucket, the undetected fallback, per-host existence checks, `--force`, and all three deprecated aliases.
- [x] Ran end to end against a throwaway GitLab-remote repo: `klaussy pr-template` wrote `.gitlab/merge_request_templates/Default.md`, and `klaussy github` on the same repo printed the deprecation warning and correctly skipped as already-present.
- [x] `test_mcp.py`'s exhaustive tool-name assertion updated, which is what caught the new tool needing registration.

## Notes

- The pre-commit guard caught a silent failure in my first draft: `host = forge or detect_forge(repo)` accepted any string, so `--forge gitlub` would take the GitHub branch and write the wrong path with no warning. Now `_resolve_host()` validates against `FORGES` (case-insensitively) and raises; the CLI turns that into a clean message and exit 1, matching how `--agents` is handled.
- `backends.py` still carries an unrelated in-flight change in the working tree; it's untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
