### PR TITLE
fix(forge): replace the Bitbucket shrug with verified REST calls

### DIFF
--- a/src/klaussy/forge.py
+++ b/src/klaussy/forge.py
@@ -85,8 +85,8 @@ _CLIS = {FORGE_GITHUB: "gh", FORGE_GITLAB: "glab"}
 def forge_cli(forge: str) -> str | None:
     """Return the CLI a forge is driven with, or None where none exists.
 
-    Bitbucket has no first-party CLI, and allow-listing a command nobody has
-    is noise, so it gets None rather than a guess.
+    Bitbucket is driven through REST, and `Bash(curl *)` would grant reach far
+    past the forge, so it stays None: that prompt is worth keeping.
     """
     return _CLIS.get(forge)
 

--- a/src/klaussy/templates/forge/bitbucket.md
+++ b/src/klaussy/templates/forge/bitbucket.md
@@ -1,11 +1,23 @@
 ### Forge commands (Bitbucket / Atlassian)
 
-`origin` points at Bitbucket, which has no first-party CLI, so there is no command to copy. Use the REST API only if the user already has credentials configured (an app password, `BITBUCKET_TOKEN`, or a `~/.netrc` entry). Otherwise ask them to paste the ticket or request content, and hand back the steps to apply on their side.
+`origin` points at Bitbucket, which has no first-party CLI — Atlassian's `acli` covers Jira only. The REST API is the adapter, so these are `curl` calls, and they need credentials: an app password (`curl -u <user>:<app-password>`), a `BITBUCKET_TOKEN` bearer, or a `~/.netrc` entry. If none is configured, ask the user rather than hunting for one.
 
-- **Bitbucket Cloud**: `https://api.bitbucket.org/2.0/repositories/<workspace>/<repo>/pullrequests/<id>`; comments live under `/comments`.
-- **Bitbucket Data Center** (self-hosted, formerly Stash): `<host>/rest/api/1.0/projects/<key>/repos/<slug>/pull-requests/<id>`. The payload shapes differ from Cloud, so establish which one this host is before composing a call.
-- **Jira tickets**: `acli jira workitem view` (the Atlassian CLI covers Jira only, it has no Bitbucket pull-request commands). Confirm the flags with `acli jira workitem view --help`. Without it, ask for the ticket text.
+Everything below is Bitbucket **Cloud**, base `https://api.bitbucket.org/2.0`, with `<ws>` the workspace and `<repo>` the slug.
 
-**Retargeting is the one to be careful with.** A `PUT` to the pull request is the documented way to change its destination branch, but Atlassian's reference doesn't spell out which fields are updatable, and the update is known to return `200` while silently ignoring parts of the body. Never report a retarget as done on the strength of a status code: re-read the pull request and confirm the destination actually changed, or hand the user the one-click path (the destination branch name in the PR header is editable in the UI).
+| Need | Call |
+| :--- | :--- |
+| Read a ticket | `acli jira workitem view` (Jira only, confirm flags with `--help`) |
+| Open a request | `POST /repositories/<ws>/<repo>/pullrequests` with `title` and `source.branch.name` |
+| Request status | `GET /repositories/<ws>/<repo>/pullrequests/<id>` — `state` is `OPEN`/`MERGED`/`DECLINED` |
+| CI status | `GET /repositories/<ws>/<repo>/pipelines?sort=-created_on`, then `/pipelines/<uuid>/steps` for a failing run |
+| Read review comments | `GET /repositories/<ws>/<repo>/pullrequests/<id>/comments` |
+| Reply in a thread | `POST …/comments` with `{"content": {"raw": "<text>"}, "parent": {"id": <comment-id>}}` |
+| Resolve a thread | `POST …/comments/<comment-id>/resolve` (`DELETE` the same path reopens it) |
+| Retarget a request | `PUT …/pullrequests/<id>` with `{"destination": {"branch": {"name": "<branch>"}}}` |
 
-Never guess an endpoint, a payload shape, or an auth scheme here. A wrong `POST` writes a comment on the wrong request and can't be taken back; asking costs a turn.
+Four things worth knowing before you use these:
+
+- **Threading is `parent`, not a separate endpoint.** A reply is an ordinary comment carrying `parent.id`; omit it and the comment lands at top level. Inline comments carry an `inline` object with `path` and line numbers.
+- **Only open pull requests can be mutated.** The retarget `PUT` is documented for changing a request's branches, but a merged or declined request rejects it.
+- **A `200` on that `PUT` is not proof.** Bitbucket accepts the whole pull-request object as the body and quietly ignores fields it won't change, so send only what you're changing and then re-read the request to confirm `destination.branch.name` actually moved.
+- **Bitbucket Data Center is a different API.** Self-hosted (formerly Stash) serves `<host>/rest/api/1.0/projects/<key>/repos/<slug>/pull-requests/<id>` with different payload shapes, and none of the above is verified against it. Establish which one this host is first, and check that instance's own API docs before composing a call.

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -86,7 +86,15 @@ class TestBlock:
         assert "-F resolved=true" in forge_block(FORGE_GITLAB)
         assert "notes/<note-id>" in forge_block(FORGE_GITLAB)
         assert "acli jira workitem view" in forge_block(FORGE_BITBUCKET)
-        assert "silently ignoring" in forge_block(FORGE_BITBUCKET)
+        assert "quietly ignores fields" in forge_block(FORGE_BITBUCKET)
+        # From the published OpenAPI spec and confirmed on a live public repo:
+        # threading is a parent id, resolution is its own endpoint, and the
+        # retarget path is destination.branch.name.
+        bitbucket = forge_block(FORGE_BITBUCKET)
+        assert '"parent": {"id": <comment-id>}' in bitbucket
+        assert "/resolve" in bitbucket
+        assert '"destination": {"branch": {"name": "<branch>"}}' in bitbucket
+        assert "Only open pull requests can be mutated" in bitbucket
         # Verified by introspecting the live GraphQL schema: threadId is the
         # only required input, and it comes from reviewThreads, not the comment.
         assert "resolveReviewThread(input: {threadId: $id})" in forge_block(FORGE_GITHUB)

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -87,9 +87,7 @@ class TestBlock:
         assert "notes/<note-id>" in forge_block(FORGE_GITLAB)
         assert "acli jira workitem view" in forge_block(FORGE_BITBUCKET)
         assert "quietly ignores fields" in forge_block(FORGE_BITBUCKET)
-        # From the published OpenAPI spec and confirmed on a live public repo:
-        # threading is a parent id, resolution is its own endpoint, and the
-        # retarget path is destination.branch.name.
+        # Shapes taken from the published OpenAPI spec, confirmed on a live repo.
         bitbucket = forge_block(FORGE_BITBUCKET)
         assert '"parent": {"id": <comment-id>}' in bitbucket
         assert "/resolve" in bitbucket


### PR DESCRIPTION
> Stacked on #33 → #32 → #31 → #30. Review those first; this diff includes them until they merge.

## Summary

The Bitbucket block told the agent to ask instead of act, because Atlassian's REST reference is JS-rendered and returns nothing to a fetch. That was the right default while the docs were unreadable, but it wasn't the API's fault — Bitbucket publishes an OpenAPI spec, and its read endpoints are open on public repos. Both were retrievable all along; the earlier attempt just went through a summarizer that truncated them.

Downloading the spec and reading it locally answers every question the docs site wouldn't, and Bitbucket turns out to support more than the block credited it with.

## What the spec and the live API established

| Claim | Before | Now |
| :--- | :--- | :--- |
| Reply in a thread | unverified | a comment carrying `parent.id` — confirmed live, comment `49696012` replies to `49695834` |
| Resolve a thread | assumed absent | `POST …/comments/<id>/resolve`, with `DELETE` to reopen |
| Retarget | "PUT, unconfirmed" | documented as changing a request's branches; `destination.branch.name` matches a live PR's shape |
| Constraint | unknown | **only open requests can be mutated** — merged and declined reject the PUT |
| CI status | "Pipelines REST, unverified" | `GET /pipelines?sort=-created_on`, then `/pipelines/<uuid>/steps` |

All three paths the block already named are confirmed present with the right methods (`GET`/`PUT` on the request, `GET`/`POST` on comments), base `/2.0`.

## Changes

- `templates/forge/bitbucket.md` — rewritten from a caveat into a command table with the credential options up front (app password, `BITBUCKET_TOKEN`, `.netrc`), plus the four traps: threading is a `parent` id rather than a separate endpoint, only open requests are mutable, a `200` on the retarget isn't proof, and Data Center is a different API.
- `tests/test_forge.py` — pins the reply shape, the resolve path, the retarget body, and the open-only constraint.
- `forge.py` — the docstring now says why Bitbucket gets no permission grant, which changed: it isn't that no tooling exists, it's that the tooling is `curl`.

## What deliberately did not change

**Bitbucket still gets no entry in the allow-list.** It's driven with `curl`, and `Bash(curl *)` grants reach far past the forge — every host on the internet, including somewhere to send a file. That prompt is worth keeping, and it's a different judgment from `Bash(gh *)`, which can only talk to GitHub.

**The 200-without-effect warning stays.** The PUT body is the entire pull-request object and fields it won't change are dropped silently, so the block still tells the agent to re-read the request rather than trust the status code.

**Data Center remains unverified.** Self-hosted serves `/rest/api/1.0/…` with different payload shapes, and I have no instance to check against. It's labelled as such rather than assumed to match Cloud.

## Test Plan

- [x] `pytest tests/` — 698 passed, 15 skipped. `ruff check src/ tests/` clean.
- [x] Spec parsed locally from `api.bitbucket.org/swagger.json` (943 KB, `swagger: 2.0`, basePath `/2.0`): paths, methods, the PUT description, and the `pullrequest_endpoint.branch.name` nesting all read directly rather than through a summarizer.
- [x] Read endpoints exercised unauthenticated against `atlassian/atlaskit` PR #4635: `destination.branch.name` returned `master`, and the comment list showed both an inline comment and a threaded reply with `parent.id`.
- [x] No write was attempted. `POST`/`PUT`/`resolve` come from the spec only, which is why the block tells the agent to verify a retarget by re-reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
