### PR TITLE
feat(opencode): declare a local Ollama provider in opencode.json

### DIFF
--- a/src/klaussy/agents/backends.py
+++ b/src/klaussy/agents/backends.py
@@ -943,6 +943,20 @@ class OpenCodeBackend(GenericBackend):
             # opencode loads path-scoped rule files only when listed here; the
             # glob is harmless when `.opencode/rules/` is empty or absent.
             "instructions": [".opencode/rules/*.md"],
+            "provider": {
+                "ollama": {
+                    "npm": "@ai-sdk/openai",
+                    "name": "ollama",
+                    "options": {"baseURL": "http://127.0.0.1:11434/v1"},
+                    "models": {
+                        "qwen3-coder:30b": {"name": "qwen3-coder:30b"},
+                        "qwen2.5-coder:32b": {"name": "qwen2.5-coder:32b"},
+                        "qwen2.5-coder:14b": {"name": "qwen2.5-coder:14b"},
+                        "qwen2.5-coder:7b": {"name": "qwen2.5-coder:7b"},
+                        "deepseek-coder-v2": {"name": "deepseek-coder-v2"},
+                    },
+                }
+            },
             "permission": {"read": read_rules, "bash": bash_rules},
         }
 

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -154,6 +154,17 @@ class TestOpenCodeSettings:
         assert config["permission"]["bash"]["pytest *"] == "allow"
         assert config["permission"]["bash"]["*"] == "ask"
 
+    def test_ollama_provider_points_at_a_local_server(self, repo):
+        # The provider block is what lets opencode talk to a local Ollama; the
+        # OpenAI-compatible /v1 suffix on the loopback URL is load-bearing.
+        OpenCodeBackend().emit_settings(repo, force=True)
+        config = json.loads((repo / "opencode.json").read_text())
+        ollama = config["provider"]["ollama"]
+        assert ollama["npm"] == "@ai-sdk/openai"
+        assert ollama["options"]["baseURL"].endswith("/v1")
+        assert "127.0.0.1:11434" in ollama["options"]["baseURL"]
+        assert ollama["models"], "a provider with no models offers nothing to select"
+
     def test_wildcard_default_is_first_so_specific_rules_win(self, repo):
         # opencode is last-match-wins: the broad "*" must precede the specific
         # allow/deny rules, or it would re-allow secret reads / re-gate the


### PR DESCRIPTION
## Summary

Adds a local Ollama provider to the generated `opencode.json`, so a scaffolded repo can point opencode at a model running on the machine instead of a hosted one.

opencode reaches Ollama through the OpenAI-compatible adapter, which means the provider has to be declared — with the `/v1` suffix on the base URL — before any local model shows up as selectable. The models shipped are the ones people actually run locally: `qwen3-coder:30b`, three `qwen2.5-coder` sizes, and `deepseek-coder-v2`.

## Changes

- `backends.py` — `OpenCodeBackend.emit_settings()` writes a `provider.ollama` block alongside the existing `instructions` and `permission` config.
- `tests/test_opencode.py` — pins the adapter, the loopback URL with its `/v1` suffix, and that the model list isn't empty.

## Test Plan

- [x] `pytest tests/` — 657 passed, 15 skipped (1 new). `ruff check` and `ruff format --check` clean across `src/` and `tests/`.

## Notes

- Declaring a provider is free when Ollama isn't installed: opencode only dials it if a model under it is selected, so this doesn't affect anyone running a hosted model.
- It mirrors the commented Ollama example already in the generated aider config, so the two backends now tell the same story about local models.
- Base branch is `main` — unrelated to the forge stack in #30–#34.
- `ruff format` collapsed the single-key `options` dict and added trailing commas on the way in. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
