### PR TITLE
Release 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.21.0] - 2026-08-05
+
+### Added
+
+- **`<repo>-restack` skill** — rebases a stack of dependent branches after the
+  base moved, the bottom branch landed, or a mid-stack branch was amended. The
+  parent/child chain comes from git ancestry (`merge-base --is-ancestor`, with
+  the nearest ancestor winning) rather than from PR metadata, so it works the
+  same on GitHub, GitLab, Bitbucket, or no forge at all, and the confirmed
+  mapping is stored as `branch.<child>.klaussyParent` so later runs don't
+  re-derive it. Each branch is rebased `--onto` its new parent off the parent's
+  recorded old tip, which is what keeps a child from replaying its parent's
+  commits a second time, and the result is verified with `range-diff`. A parent
+  that landed by squash or rebase merge is detected by comparing trees
+  (`merge-tree --write-tree`), since those rewrite SHAs and slip past ancestry.
+  Force-pushes are leased and bottom-up, never on the base branch. Retargeting
+  the PR/MR base is the only forge-dependent step, runs last, and prints the
+  remaining manual steps rather than failing when no CLI is available.
+
+### Fixed
+
+- Cap `mcp` below 2.0 so the test suite runs against the supported FastMCP API.
+
+### Documentation
+
+- README: `<repo>-restack` in the skills table; the downloads badge reports
+  total installs rather than the last month.
+
 ## [0.20.0] - 2026-07-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.20.0"
+version = "0.21.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), opencode, and Kimi Code CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read


### PR DESCRIPTION
## Summary

Release 0.21.0, covering the restack skill merged in #30.

Minor bump: one `feat:` since `v0.20.0`, no breaking change. The other commits in range are a `fix(deps):` and two `docs:`.

## Changes

- `pyproject.toml` and `src/klaussy/__init__.py` → `0.21.0` (both declarations; a half-bumped release is the usual failure here).
- `CHANGELOG.md` → a `[0.21.0] - 2026-08-05` entry in the existing Keep a Changelog format, with Added / Fixed / Documentation sections matching the commit range.

## Test Plan

- [x] `pytest tests/` — 656 passed, 15 skipped on the bumped tree. `ruff check` and `ruff format --check` clean.
- [x] `python -m build` succeeds: `klaussy_agents-0.21.0-py3-none-any.whl` and the sdist.
- [x] **Checked the wheel actually carries the new skill**, since `package-data` globs are the thing that silently drops a new template directory: all 26 skill templates are present including `klaussy/templates/skills/restack/SKILL.md`.
- [x] Confirmed that template ships only `{{REPO}}` and `{{BASE_BRANCH}}` — both substituted by the scaffolders in this release. The `{{FORGE}}` token is #31 and isn't on `main`, so nothing here references a token this version can't resolve.

## Notes

- Only #30 is in this release. #31–#36 (the `{{FORGE}}` token, forge permissions, per-host PR template, Bitbucket verification, and the restack evals) are still open and will land in a later version.
- Publishing happens on the `v0.21.0` tag push, which triggers the PyPI job in `release.yml`. The tag goes on the merge commit, matching how `v0.20.0` was tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
