### PR TITLE
docs(readme): show how to invoke the skills after klaussy init

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ klaussy init
 
 *Auto-detects your base branch and stack, then scaffolds all targets. To target specific agents, run `klaussy init --agents claude,cursor`.*
 
+Then use the skills. Every one is namespaced to your repo, so in a repo called `payments-service` you'd hand a whole task to the owl:
+
+```
+/payments-service-rest-of-the-owl https://linear.app/acme/issue/PAY-1234
+/payments-service-rest-of-the-owl add a --dry-run flag to the reconciler CLI
+```
+
+*A ticket link or a plain description both work. See [Using the skills](#using-the-skills) for the naming rule and the rest of the set.*
+
 ---
 
 ## 🤖 Supported Agents & Targets
@@ -157,6 +166,29 @@ The tricky part is that a committed hook command can't portably name a Python in
 pip install klaussy-agents
 klaussy init
 ```
+
+### Using the skills
+
+After `klaussy init`, the skills are in your repo and invoked by name. The name is always `<your repo name>-<skill>`, lowercased with anything that isn't a letter or digit turned into a hyphen — so `My_App` becomes `my-app-review`, and `Payments Service` becomes `payments-service-review`.
+
+```
+/<your repo name>-rest-of-the-owl <task link or description>
+```
+
+Hand it a ticket URL or type the task out, and it runs the whole loop: plan, implement, test, self-review, QA with evidence, open a humanized PR, then poll CI and review until the PR is green. It stops before merging, so you keep that button.
+
+The ones you'll reach for daily:
+
+```
+/<repo>-review                      # senior-level review of the branch
+/<repo>-debug the checkout total is wrong for EU orders
+/<repo>-restack                     # rebase a stack of dependent PRs
+/<repo>-grant-permissions           # stop the agent asking about routine commands
+```
+
+Most skills also trigger on their own when the work matches — describe a bug and `debug` picks it up. Seven are explicit-only, because you don't want them firing on their own: `commit`, `pr`, `precommit`, `release`, `restack`, `new-worktree`, and `document`.
+
+*On other agents the same skills land in that agent's own directory (`.cursor/skills/`, `.gemini/skills/`, `.opencode/skills/`, `.github/skills/`, `.agents/skills/`) and you invoke them however that agent invokes skills. The slash form above is Claude Code's.*
 
 ### As a Claude Code Plugin
 ```


### PR DESCRIPTION
## Summary

Both the Quick Start and the Installation & Usage sections stopped at `klaussy init`, which leaves a reader with a scaffolded repo and no idea the skills are slash commands named after it. This adds the step after install.

## Changes

**Quick Start** gains the invocation right after the scaffold command, in a concrete repo so the naming is obvious rather than abstract:

```
/payments-service-rest-of-the-owl https://linear.app/acme/issue/PAY-1234
/payments-service-rest-of-the-owl add a --dry-run flag to the reconciler CLI
```

**A new "Using the skills" subsection** under Installation & Usage, placed right after the CLI install since `klaussy init` is what produces the skills. It covers:

- The general form, `/<your repo name>-rest-of-the-owl <task link or description>`, and what the owl actually does end to end.
- **The naming rule, including the cases that surprise people.** The namespace is the repo name lowercased with every non-alphanumeric run collapsed to a hyphen, so `My_App` gives `/my-app-review` and `Payments Service` gives `/payments-service-review`. Someone in a repo with capitals or an underscore would otherwise type a command that doesn't exist.
- Four everyday skills with realistic arguments rather than bare names.
- Which skills auto-trigger and which don't: seven are explicit-only (`commit`, `pr`, `precommit`, `release`, `restack`, `new-worktree`, `document`), because those firing on their own is exactly what you don't want.
- That the slash form is Claude Code's, and other agents invoke skills their own way from their own directories. Claiming `/name` works everywhere would be wrong.

## Test Plan

Docs only, but the claims are checked against the code rather than written from memory:

- [x] Every skill the README now advertises (`rest-of-the-owl`, `review`, `debug`, `restack`, `grant-permissions`) is in `SKILL_NAMES`.
- [x] Both namespace examples were run through `sanitize_skill_namespace()`: `My_App` → `my-app` and `Payments Service` → `payments-service`, matching what the README says.
- [x] The explicit-only list was diffed against the templates carrying `disable-model-invocation: true` — same seven, so "Seven" is accurate.
- [x] The per-agent skill directories were read out of `backends.py` rather than assumed.
- [x] The Quick Start link resolves to the new `### Using the skills` heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
