### PR TITLE
Release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.22.0] - 2026-08-05
+
+### Added
+
+- **Skills adapt to your hosting provider.** Skills that touch a ticket, a
+  pull/merge request, or CI hardcoded `gh`, which quietly made them
+  GitHub-only. The provider is now detected once from `origin` and one tailored
+  command block is substituted into `restack`, `address-review`, and
+  `rest-of-the-owl`, the same mechanism as the shared humanize block. A GitLab
+  repo's skills ship `glab mr` commands and discussion semantics rather than
+  `gh pr` and review threads. Detection matches the *host*, so a repo named
+  `github-actions-demo` hosted elsewhere isn't misread, and enterprise hosts
+  like `github.acme.com` are picked up. A provider klaussy can't identify gets
+  a block that tells the agent to ask rather than invent an endpoint.
+- **The host's CLI is allow-listed.** Generated permissions include `Bash(gh *)`
+  or `Bash(glab *)` for the detected host, in both the Claude settings and the
+  prefix-based agents, and `grant-permissions` learned to look the CLI up from
+  `origin` — no marker file announces it the way `pyproject.toml` announces
+  pytest. Bitbucket gets nothing: it's driven with `curl`, which reaches far
+  past the forge, so that prompt is worth keeping.
+- **`klaussy pr-template` writes the template where the host reads it.** Every
+  init wrote `.github/PULL_REQUEST_TEMPLATE.md` regardless of provider, inert
+  on two of three. GitLab now gets `.gitlab/merge_request_templates/`, and
+  Bitbucket is skipped with a reason, since its default description is a repo
+  setting rather than a tracked file. An undetected host keeps the GitHub
+  layout and says so, with `--forge` to override.
+
+### Changed
+
+- **`klaussy github` is now `klaussy pr-template`** across the CLI, the MCP
+  tool (`klaussy_pr_template`), and the toolkit (`toolkit.pr_template()`). The
+  old names still work as deprecated aliases and will be removed in the next
+  major version.
+
+### Fixed
+
+- The Bitbucket command block was a caveat rather than commands, because
+  Atlassian's REST reference doesn't render for retrieval. Reading the
+  published OpenAPI spec directly established that threads are real (a reply is
+  a comment carrying `parent.id`), that resolution has its own endpoint, and
+  that retargeting is documented — along with the constraint nobody mentions,
+  that only open requests can be mutated.
+- GitLab thread resolution is documented per-discussion *and* per-note; the
+  block previously claimed the latter didn't exist. Boolean fields need `-F`,
+  since `-f` sends the literal string.
+
+### Added (opencode)
+
+- A local **Ollama provider** in the generated `opencode.json`, so a scaffolded
+  repo can point opencode at a model on the machine. Declaring it costs nothing
+  when Ollama isn't installed.
+
+### Internal
+
+- Evals for the restack skill, run against a live model, pinning what decides
+  whether history survives a restack: `--onto` off the parent's recorded old
+  tip, bottom-up order, leased force-pushes, and never the base branch. The
+  eval harness was substituting every token except `{{FORGE}}`, so it had been
+  judging a spec no scaffolded repo is ever served.
+
+### Documentation
+
+- README: how to invoke the skills after `klaussy init` — the
+  `/<your repo name>-<skill>` form, the naming rule for repo names with
+  capitals or spaces, and which skills never auto-trigger.
+
 ## [0.21.0] - 2026-08-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.21.0"
+version = "0.22.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), opencode, and Kimi Code CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read


### PR DESCRIPTION
## Summary

Release 0.22.0 — the forge work (#31–#34, #36), the opencode Ollama provider (#35), the recovery merge (#39), and the README usage docs (#38).

Minor bump: three `feat:` commits since `v0.21.0`, no breaking change. The `klaussy github` → `klaussy pr-template` rename keeps the old names as deprecated aliases, so nothing breaks for existing configs.

## Changes

- `pyproject.toml` and `src/klaussy/__init__.py` → `0.22.0` (both declarations).
- `CHANGELOG.md` → a `[0.22.0]` entry covering the per-host `{{FORGE}}` adaptation, the CLI allow-listing, `pr-template` and its rename, the Bitbucket and GitLab command corrections, the Ollama provider, the restack evals, and the README docs.

## Test Plan

- [x] `pytest tests/` — 705 passed, 23 skipped on the bumped tree. `ruff check` clean.
- [x] `python -m build` succeeds for both artifacts.
- [x] **The new `templates/forge/` directory is in the wheel** — all four blocks (`github`, `gitlab`, `bitbucket`, `unknown`). A new template directory silently missing from `package-data` is exactly the failure this release could have shipped.
- [x] **`{{FORGE}}` resolves rather than shipping literal.** Scaffolded a throwaway repo with a GitLab remote from the built code: no literal token in the output, and `glab mr update` present. A token that reached users as text would be the worst outcome of this release.
- [x] `pr_template.py` ships and the deprecated `github.py` shim is still in the wheel, so pinned imports keep working.

## Notes

- #32, #33, #34, and #36 originally merged into their parent branches rather than `main` — the stack was merged back-to-back and GitHub retargets a stacked PR only after its parent lands. #39 brought them onto `main`; nothing was lost, and `main` was verified to contain all four before this bump.
