### PR TITLE
feat(skills): capture screen recordings as QA evidence

### DIFF
--- a/src/klaussy/templates/skills/qa/SKILL.md
+++ b/src/klaussy/templates/skills/qa/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: {{REPO}}-qa
-description: Use when the user wants the current change QA'd and PR-ready evidence captured. Classifies the diff and runs the verification that actually fits it — screenshots for UI/frontend changes, endpoint or e2e runs for backend, command output for a CLI, tests for a library — then saves artifacts and writes a QA summary. Right-sizes QA to the change; it does not write features or fix bugs.
+description: Use when the user wants the current change QA'd and PR-ready evidence captured. Classifies the diff and runs the verification that actually fits it — screen recordings and screenshots for UI/frontend changes, endpoint or e2e runs for backend, command output for a CLI, tests for a library — then saves artifacts and writes a QA summary. Right-sizes QA to the change; it does not write features or fix bugs.
 allowed-tools: Read Grep Glob Bash Edit Write
 ---
 
-QA the current change and capture evidence a reviewer can trust. The point is to run *the QA that's valid for this change* — a UI tweak needs screenshots, a backend fix needs the endpoint exercised and the suite run, a CLI change needs its commands run. Don't screenshot a database migration; don't run the full browser e2e suite for a one-line helper.
+QA the current change and capture evidence a reviewer can trust. The point is to run *the QA that's valid for this change* — a UI tweak needs a recording of the interaction plus screenshots, a backend fix needs the endpoint exercised and the suite run, a CLI change needs its commands run. Don't screenshot a database migration; don't run the full browser e2e suite for a one-line helper.
+
+**Record the change in motion whenever you can.** A screen recording shows a reviewer what a still frame can't — the interaction, the transition, the loading and error states, the thing actually working end to end. Whenever the surface you're QA'ing has motion or a multi-step flow, capture video first and pull stills from it (or take them alongside); fall back to screenshots only when recording isn't available.
 
 ## Steps
 
-1. **Read CLAUDE.md** for how this project builds, runs, and tests, plus any e2e/screenshot tooling it already has. **Read any `.claude/rules/*.md`** whose `paths:` glob covers the changed files — they often name the ports, fixtures, or QA conventions for that layer.
+1. **Read CLAUDE.md** for how this project builds, runs, and tests, plus any e2e, screenshot, or video-capture tooling it already has. **Read any `.claude/rules/*.md`** whose `paths:` glob covers the changed files — they often name the ports, fixtures, or QA conventions for that layer.
 2. **See what changed.** `git diff {{BASE_BRANCH}}...HEAD` for the branch's work, plus `git diff` / `git diff --cached` for uncommitted edits. **Classify each surface the diff touches** (a change can span more than one — QA each with its own method):
    - **UI / frontend** — components, styles, templates, pages, client-side behavior.
    - **Backend / API / service** — routes, handlers, business logic, jobs, DB.
@@ -16,22 +18,43 @@ QA the current change and capture evidence a reviewer can trust. The point is to
    - **Library / SDK** — importable code with no runtime surface of its own.
    - **Docs / config / infra only** — no runtime behavior to observe.
 3. **Run the QA that fits each surface** (use **`{{REPO}}-run`** whenever you need to bring the app or service up):
-   - **UI / frontend** → **capture screenshots.** Prefer the repo's own tooling (Playwright, Cypress, Storybook, a visual-test harness) — it already knows how to reach each screen. Otherwise launch the app via `{{REPO}}-run` and drive a headless browser (Playwright/Puppeteer) if one is installed. Capture the states the change actually affects: the default view, the changed interaction, and empty/error or responsive breakpoints when layout or state handling changed. Grab a *before* shot from `{{BASE_BRANCH}}` too when the branch point is cheap to check out, so the diff is visible. Note what changed visually.
-   - **Backend / API / service** → run the test suite and any integration/e2e that covers the area, then **exercise the changed path for real**: bring the service up, hit the endpoint (curl/httpie/the project's client), and capture the request → response and any relevant log lines.
-   - **CLI / tool** → run the representative commands that exercise the change (not just `--help`); capture stdout, stderr, and exit codes.
+   - **UI / frontend** → **record the flow, then capture screenshots.** Prefer the repo's own tooling (Playwright, Cypress, Storybook, a visual-test harness) — it already knows how to reach each screen, and most of it records video with one flag (see *Capturing a recording* below). Otherwise launch the app via `{{REPO}}-run` and drive a browser (Playwright/Puppeteer, or whatever browser-control tooling your agent surface has) with recording turned on. Record the change actually being used: the path a user takes through it, start to finish. Then capture stills for the states the change affects — the default view, the changed interaction, and empty/error or responsive breakpoints when layout or state handling changed. Grab a *before* recording or shot from `{{BASE_BRANCH}}` too when the branch point is cheap to check out, so the diff is visible. Note what changed visually.
+   - **Backend / API / service** → run the test suite and any integration/e2e that covers the area, then **exercise the changed path for real**: bring the service up, hit the endpoint (curl/httpie/the project's client), and capture the request → response and any relevant log lines. If the change is visible through a UI or a dashboard, record that too.
+   - **CLI / tool** → run the representative commands that exercise the change (not just `--help`); capture stdout, stderr, and exit codes. For anything interactive, long-running, or with meaningful terminal output (a TUI, a progress display, a prompt flow), record the terminal — `asciinema rec` if it's installed, otherwise a screen recording — so the reviewer sees the session rather than a transcript.
    - **Library / SDK** → run the unit tests plus a small usage snippet that calls the changed API.
    - **Docs / config / infra only** → there's nothing to observe at runtime. Say so and stop — don't manufacture QA.
-4. **Save the artifacts where the user can actually open them** — a subfolder named `<repo>-<branch>` inside their Downloads folder (e.g. `myapp-feature-login/`), so screenshots land somewhere they'll look. Resolve the destination for the OS you're on:
+4. **Save the artifacts where the user can actually open them** — a subfolder named `<repo>-<branch>` inside their Downloads folder (e.g. `myapp-feature-login/`), so recordings and screenshots land somewhere they'll look. Resolve the destination for the OS you're on:
    - **macOS / Linux**: `~/Downloads/<repo>-<branch>/`
    - **Windows**: `%USERPROFILE%\Downloads\<repo>-<branch>\` (PowerShell: `$env:USERPROFILE\Downloads\...`)
 
-   Derive `<repo>` from the repo root's folder name and `<branch>` from the current branch (`git rev-parse --show-toplevel` and `git rev-parse --abbrev-ref HEAD`), replacing any `/` in the branch with `-` so it's one valid folder name. Create the folder if it doesn't exist, then write screenshots as PNGs and captured command/HTTP output as text into it — keep artifacts out of the repo tree; they're evidence for a human, not source to commit. If there's no Downloads folder (a headless CI box), fall back to the user's home directory. Report the absolute folder path so the user can find it.
-5. **Write a QA summary** suited to drop into a PR's Test Plan / QA section: which surfaces changed, what QA ran for each, the evidence (screenshot paths, captured output, test results), pass/fail, and anything you could NOT cover and why. Lead with the result, keep it tight.
+   Derive `<repo>` from the repo root's folder name and `<branch>` from the current branch (`git rev-parse --show-toplevel` and `git rev-parse --abbrev-ref HEAD`), replacing any `/` in the branch with `-` so it's one valid folder name. Create the folder if it doesn't exist, then write recordings as MP4 or WebM, screenshots as PNGs, and captured command/HTTP output as text into it — keep artifacts out of the repo tree; they're evidence for a human, not source to commit. Give each file a name that says what it shows (`login-error-state.png`, `checkout-flow.mp4`), and move recordings out of whatever temp directory the test runner dropped them in — Playwright and Cypress write videos under their own output folders and overwrite them on the next run. If there's no Downloads folder (a headless CI box), fall back to the user's home directory. Report the absolute folder path so the user can find it.
+5. **Write a QA summary** suited to drop into a PR's Test Plan / QA section: which surfaces changed, what QA ran for each, the evidence (recording and screenshot paths, captured output, test results), pass/fail, and anything you could NOT cover and why. Say explicitly when a surface has no recording and why. Lead with the result, keep it tight.
+
+## Capturing a recording
+
+Work down this list and use the first option that's actually available — don't install new tooling just to record.
+
+- **The repo's existing e2e/browser tooling**, which almost always records already:
+  - **Playwright** — `use: { video: 'on' }` in `playwright.config`, or `browser.newContext({ recordVideo: { dir: '...' } })` in a standalone script. Writes WebM per context.
+  - **Cypress** — records video by default for `cypress run`; check `videosFolder`.
+  - **Puppeteer** — `page.screencast({ path: '...webm' })` (Chrome 126+), otherwise a burst of screenshots.
+  - Storybook/visual harnesses, or any project-specific capture script.
+- **Your agent surface's own browser control** — Claude in Chrome, Copilot's browser tooling, an IDE's integrated browser, or a browser-automation MCP server. If it can drive the page it can usually capture frames; use its recording feature if it has one, and a tight screenshot sequence at each step if it doesn't.
+- **The browser itself** — Chrome DevTools Recorder to capture a flow, or the browser's built-in screen capture.
+- **The OS**, when the change lives outside a browser (a desktop app, an installer, a TUI):
+  - macOS: `screencapture -v ~/Downloads/<folder>/flow.mp4` (Ctrl-C to stop)
+  - Linux: `ffmpeg -f x11grab -i :0.0 flow.mp4` (or the desktop's own recorder)
+  - Windows: `ffmpeg -f gdigrab -i desktop flow.mp4`, or Xbox Game Bar (`Win+Alt+R`)
+- **Terminal sessions** — `asciinema rec flow.cast`.
+
+Keep recordings short and pointed: the flow the change affects, nothing else. Thirty seconds of the actual interaction beats five minutes of navigation. If none of these is available, say so in the summary and fall back to screenshots plus written repro steps.
 
 ## Rules
 
 - **Right-size QA to the diff.** Only exercise what the change touches. A reviewer doesn't need forty screenshots or a full e2e run for a two-line fix — capture the states that actually changed, and skip surfaces the diff doesn't reach.
-- **Never fabricate evidence.** If you can't capture a screenshot (no browser tooling, no display, no fixture data), say so plainly and give the manual repro steps a human would follow — a described gap beats a faked artifact.
+- **Record when recording is possible.** For anything with an interaction, a transition, or more than one step, a recording is the evidence; screenshots are the fallback, not the default. A still can't show that the flow works.
+- **Never fabricate evidence.** If you can't capture a recording or screenshot (no browser tooling, no display, no fixture data), say so plainly and give the manual repro steps a human would follow — a described gap beats a faked artifact. Never describe a recording you didn't make.
+- **Don't record secrets.** A capture picks up whatever is on screen — tokens, real user data, an open password manager, unrelated browser tabs. Record the app window, not the whole desktop, and check the artifact before you point the user at it.
 - **Don't change code to make QA pass.** A failure here is a real signal — that's a bug for the debug skill, not something to patch around. Report it.
 - **Local / dev only.** Never QA against production or with production credentials unless the user explicitly says so. Tear down any app or server you started.
 

--- a/src/klaussy/templates/skills/rest-of-the-owl/SKILL.md
+++ b/src/klaussy/templates/skills/rest-of-the-owl/SKILL.md
@@ -36,14 +36,16 @@ Follow **`{{REPO}}-review`** against the working diff (`git diff {{BASE_BRANCH}}
 
 ## Phase 4 — QA the change
 
-Follow **`{{REPO}}-qa`**. It classifies the diff and runs only the QA that fits: screenshots for a UI change, the exercised endpoint plus e2e for a backend change, command output for a CLI, tests for a library — and nothing at all for a docs/config-only change. Don't hand-pick the QA yourself; let the skill right-size it to what the diff touches. It saves artifacts to a `Downloads/<repo>-<branch>` folder where the user can open them — Phase 5 folds them into the PR so the reviewer sees the change actually working.
+Follow **`{{REPO}}-qa`**. It classifies the diff and runs only the QA that fits: a screen recording plus screenshots for a UI change, the exercised endpoint plus e2e for a backend change, command output for a CLI, tests for a library — and nothing at all for a docs/config-only change. Don't hand-pick the QA yourself; let the skill right-size it to what the diff touches. It saves artifacts to a `Downloads/<repo>-<branch>` folder where the user can open them — Phase 5 folds them into the PR so the reviewer sees the change actually working.
+
+**Capture a recording whenever the change can be recorded.** This run is autonomous, so the recording is often the only chance a human gets to watch the change work before they merge it. Anything with an interaction or a multi-step flow gets video — via the repo's Playwright/Cypress setup, your agent surface's browser control, the browser or OS recorder, whatever is available (the QA skill's *Capturing a recording* section ranks the options). Screenshots are the fallback when recording genuinely isn't possible, and that gap gets stated in the PR rather than glossed over.
 
 **QA is a gate, not a formality — clear it before you touch the PR.** The whole point of running QA here is to catch problems *before* they become CI failures or reviewer comments. If QA surfaces anything wrong — a screenshot that shows the change is broken or ugly, an endpoint returning the wrong response, a CLI erroring, a failing test — stop and fix it: loop back to Phase 2/3, correct the change, and re-QA. Do NOT open the PR (Phase 5) on a change that QA has shown to be broken and then rely on CI or the reviewer to catch it. Only advance once QA is genuinely clean (or the only gaps are ones you've explicitly flagged as un-QA-able and told the user about).
 
 ## Phase 5 — Open the PR (humanized)
 
 1. Commit the work on a topic branch (never commit straight to `{{BASE_BRANCH}}`) and push.
-2. Draft the PR body from the task definition + what you actually built, using **`{{REPO}}-pr`**'s Summary / Changes / Test Plan structure. Fold in the Phase 4 QA summary — for a UI change, reference the screenshots (no CLI in the adapter below uploads images, so point at the `Downloads/<repo>-<branch>` folder and prompt the user to drag them in, unless the repo has an image-hosting convention); for backend/CLI, paste the captured output.
+2. Draft the PR body from the task definition + what you actually built, using **`{{REPO}}-pr`**'s Summary / Changes / Test Plan structure. Fold in the Phase 4 QA summary — for a UI change, reference the recording and screenshots by filename (no CLI in the adapter below uploads images or video, so point at the `Downloads/<repo>-<branch>` folder and prompt the user to drag the files into the PR, unless the repo has a media-hosting convention); for backend/CLI, paste the captured output. Say which file shows what, so the drag-and-drop is a mechanical step rather than a guessing game.
 3. Run the body through **`{{REPO}}-humanize`** before it goes out — the description is the most-read prose in the whole change; it must not read like a chatbot wrote it.
 4. Open the request against `{{BASE_BRANCH}}` with the adapter's create command. Capture its number/URL and report it.
 
@@ -69,7 +71,7 @@ For the feedback that arrives, follow **`{{REPO}}-address-review`**: triage each
 
 ## Phase 9 — Land the owl (but don't merge)
 
-When CI is green and all review threads are resolved, stop. Report: the PR link, its check status, which review comments you addressed and how, and the one thing left — the user's merge. Mark all TodoWrite tasks complete.
+When CI is green and all review threads are resolved, stop. Report: the PR link, its check status, which review comments you addressed and how, the path to the QA artifacts folder and which recordings still need dragging into the PR, and the one thing left — the user's merge. Mark all TodoWrite tasks complete.
 
 State plainly if you stopped early and why (waiting on review, blocked on a decision, a failure you wouldn't paper over).
 


### PR DESCRIPTION
## Summary

The QA skill treated screenshots as the default evidence for a UI change. A still can't show that a flow actually works — it shows one frame of it. This makes a screen recording the expected artifact wherever the change has an interaction or more than one step, and demotes screenshots to the fallback.

This matters most for `rest-of-the-owl`, which runs unattended: the recording is often the only chance a human gets to watch the change work before they hit merge.

## Changes

**`qa/SKILL.md`**

- Frontmatter description and intro lead with recordings.
- UI/frontend step is now "record the flow, then capture screenshots", including a *before* recording from the base branch when the branch point is cheap to check out.
- Backend step records the UI or dashboard when the change is visible through one; CLI step records the terminal (`asciinema`, else a screen capture) for TUIs, progress output, and prompt flows.
- New **Capturing a recording** section ranking the options, first-available wins: repo e2e tooling (Playwright config, Cypress default, Puppeteer `page.screencast`) → the agent surface's own browser control (Claude in Chrome, Copilot's browser tooling, a browser MCP server) → the browser's recorder → OS recorders per platform → `asciinema`.
- Artifacts: MP4/WebM alongside PNGs, filenames that say what they show, and a note to move videos out of the test runner's output dir before the next run overwrites them.
- Two new rules: recording is the evidence and screenshots are the fallback; and don't record secrets — capture the app window, not the whole desktop, and check the file before handing it over.

**`rest-of-the-owl/SKILL.md`**

- Phase 4 requires a recording wherever one is possible, with the reasoning above.
- Phase 5 references recordings and screenshots by filename, since no forge CLI uploads media — the user drags them in, so the body says which file shows what.
- Phase 9 reports the artifacts folder and what still needs attaching.

`run/SKILL.md` is deliberately untouched. It launches and drives the app so the agent can observe; QA is the skill that produces artifacts for someone else, and it has the Write tool to do it. Adding capture to both would blur that line.

## Test Plan

- `pytest` — 705 passed, 23 skipped.
- Templates only; no code paths changed.
- Playwright/Cypress/Puppeteer/`screencapture`/`ffmpeg` invocations checked against current docs rather than written from memory. Dropped a `playwright test --video=on` CLI flag I wasn't confident existed and kept the config form.

## Checklist

- [x] Tests pass
- [x] No code changes requiring new tests
- [ ] Screenshots/recordings — n/a, this PR only edits skill prose
