### PR TITLE
Release 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.23.0] - 2026-08-05
+
+### Changed
+
+- **QA captures screen recordings, not just screenshots.** The `qa` skill
+  treated a screenshot as the evidence for a UI change, but a still frame shows
+  one moment of a flow rather than the flow working. Video is now the expected
+  artifact wherever the change has an interaction or more than one step, with
+  screenshots as the fallback. A new section ranks the capture options and takes
+  the first one already available: the repo's own e2e tooling (Playwright's
+  `video` config, Cypress, Puppeteer's `page.screencast`), then the agent
+  surface's browser control, then the browser's or the OS's recorder, then
+  `asciinema` for terminal sessions. Nothing gets installed just to record.
+  Backend changes visible through a dashboard get recorded too, as do
+  interactive CLI sessions. Artifacts land in the same
+  `Downloads/<repo>-<branch>` folder as before, now with names that say what
+  they show and a warning to move videos out of the test runner's output
+  directory before the next run overwrites them.
+- **`rest-of-the-owl` requires a recording where one is possible.** The run is
+  unattended, so the recording is often the only chance a human gets to watch
+  the change work before merging. The PR body now names each media file and what
+  it shows, since no forge CLI uploads images or video and the user drags them
+  in by hand, and the final report says which artifacts still need attaching.
+
+Two new rules come with this: a recording is the evidence rather than a nice
+extra, and don't record secrets — capture the app window instead of the whole
+desktop, and check the file before pointing anyone at it. The `run` skill is
+deliberately unchanged; it drives the app so the agent can observe, while `qa`
+is what produces artifacts for someone else.
+
 ## [0.22.0] - 2026-08-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.22.0"
+version = "0.23.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), opencode, and Kimi Code CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read


### PR DESCRIPTION
## Summary

Release 0.23.0. Ships the screen-recording changes to the `qa` and `rest-of-the-owl` skills from #41.

Minor rather than patch: the skills changed behavior for generated repos, and `.klaussy-version` gating means skill updates only land on re-scaffold when the version moves.

## Changes

- `pyproject.toml` and `src/klaussy/__init__.py` → `0.23.0`
- `CHANGELOG.md` → 0.23.0 entry

## Test Plan

- `pytest` — 705 passed, 23 skipped
- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — 80 files already formatted

Merging this and pushing `v0.23.0` triggers the release workflow, which builds, publishes to PyPI via trusted publishing, and cuts the GitHub release.

## Checklist

- [x] Tests pass
- [x] Lint and format clean
- [x] CHANGELOG updated
- [x] Version bumped in both `pyproject.toml` and `__init__.py`
