### PR TITLE
Release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
-## [Unreleased]
+## [0.24.0] - 2026-08-06
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.23.0"
+version = "0.24.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), opencode, and Kimi Code CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read


### PR DESCRIPTION
## Summary

Release 0.24.0. Ships the `split-pr` skill and the `klaussy split-prep` layer proposer from #43.

Minor rather than patch: `split-pr` is a new skill and `split-prep` a new CLI command, and `.klaussy-version` gating means skill updates only land on re-scaffold when the version moves.

## Changes

- `pyproject.toml` and `src/klaussy/__init__.py` → `0.24.0`
- `CHANGELOG.md` → `[Unreleased]` promoted to `[0.24.0] - 2026-08-06`

## Test Plan

- `pytest` — 745 passed, 37 skipped
- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — 83 files already formatted

Merging this and pushing `v0.24.0` triggers the release workflow, which builds, publishes to PyPI via trusted publishing, and cuts the GitHub release.

Note: GitHub's Actions incident from earlier today is still officially open (component listed as major outage, status `investigating`), though job success rates recovered to 99% and #43's checks ran clean. If the release run stalls or fails before the publish step, it can be re-run from the tag.

## Checklist

- [x] Tests pass
- [x] Lint and format clean
- [x] CHANGELOG updated
- [x] Version bumped in both `pyproject.toml` and `__init__.py`
