### PR TITLE
refactor(kimi): drop the comment restating kimi_hooks' docstring

### DIFF
--- a/src/klaussy/agents/hooks.py
+++ b/src/klaussy/agents/hooks.py
@@ -617,8 +617,6 @@ def kimi_hooks(repo: Path, *, force: bool) -> None:
     hooks_dir = f"{KIMI_HOME}/hooks"
 
     def _cmd(name: str) -> str:
-        # Repo root resolves at run time (the hook is global config), and the
-        # string stays free of shell syntax so cmd/PowerShell run it unchanged.
         return f"klaussy-hook --repo-relative {hooks_dir}/{name}"
 
     entries: list[tuple[str, str, str]] = []  # (event, matcher, guard filename)


### PR DESCRIPTION
## Summary

Deletes a two-line comment in `kimi_hooks` that restated its own docstring. Surfaced by the repo's pre-push guard while I was splitting a replay of #27 into a stack.

## Changes

- `src/klaussy/agents/hooks.py`: drop the comment inside `_cmd`. The docstring five lines above already carries both halves of it, that the repo root resolves at run time inside the launcher and that the string stays free of shell syntax because Kimi's four-field schema has no per-OS override. Deleted rather than condensed, since a shorter paraphrase is still a second copy of one rationale.

## Test Plan

- [x] Tests pass locally, 751 passed, 47 skipped
- [x] Manually verified, comment-only deletion; `git diff` is two removed lines with no code touched. The klaussy pre-commit guard passed the change clean on all lenses.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality, not applicable, nothing executable changed
- [x] Documentation updated if needed, the docstring already says it