### PR TITLE
feat(humanize): run the skill in four passes, not one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project are documented here. The format is based on
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Releases
 before 0.6.0 are recorded in the git tags (`v0.2.0`–`v0.5.1`).
 
+## [0.27.0] - 2026-08-11
+
+### Changed
+
+- **The humanize skill runs in four passes instead of one.** Cut (content only,
+  keeping every retained sentence word for word), voice (register only, with the
+  facts frozen), check (did the meaning survive), then the deterministic
+  scrubber. One prompt carrying every rule reliably applies the safe mechanical
+  ones and drops voice and length, which is why humanized prose stayed tidy and
+  generated-sounding however the rules were tuned. Splitting the job is what
+  fixed it: on a 330-word technical reply the four passes land at 120-167 words
+  with fragments and a stance, where the single pass sat near 200 and mirrored
+  the draft's paragraph count. Below roughly 40 words it does voice and scrub
+  only and says so.
+- **The check pass is the guard the register push needed.** Cutting and
+  restyling in separate turns means neither is verifying the claims survived, so
+  the third pass diffs the rewrite against the original for anything added
+  (including agreement the author never gave), dropped (a load-bearing noun,
+  number, identifier, or path), or reversed. Two measured failures motivated it:
+  a rewrite that turned "we invalidated the cache on every write" into "we
+  invalidated on every write", and one that inverted a concession.
+- **The shared block traded eleven bullets for three sections.** The mechanical
+  tells the scrubber deletes deterministically (filler openers, scaffolding,
+  apologies, praise, *actually*, *in order to*, *utilize*) collapsed to a single
+  line pointing at the scrubber, freeing attention for what a model has to
+  judge: a **Voice** section aimed at "a competent engineer typing this once, in
+  a hurry, who isn't going to read it back", and an **Answer what was asked,
+  then stop** section covering the closing principle, the mechanism nobody
+  asked for, and granting a point without inflating it. The block had measurably
+  hit capacity, where each new rule degraded compliance with the existing ones.
+
+### Added
+
+- **`klaussy humanize --rules`** prints the prompt-side block so another tool can
+  embed the current rules instead of maintaining a copy that drifts. Written for
+  klaussy-desktop, which builds its own review prompt when a worktree has no
+  scaffolded skill.
+- Evals for two surfaces that had none: replies to PR review feedback
+  (`test_address_review_eval.py`, covering a review bot, a hostile reviewer, a
+  request worth declining, and a one-word fix) and long-form humanizing
+  (`test_humanize_longform_eval.py`), which is where the failures actually live.
+  Every previously checked-in humanize fixture was short, and short prose always
+  passed.
+
+### Fixed
+
+- **The scrubber reaches a fixed point in one run.** Every rule matches at the
+  start of a line, so removing one tell promoted the next into that position
+  where nothing re-examined it: "It's worth noting that actually the loop leaks"
+  needed a second run to lose "Actually". It now iterates until the text stops
+  changing (7 of 8 sampled inputs needed that second pass).
+- Chatbot sign-offs beyond the exact phrase `Happy to help` are stripped, so
+  "Happy to dig into a hybrid if you see an angle I'm missing" no longer survives
+  a review reply. Mid-sentence prose ("she was happy to see it land") is left
+  alone.
+
 ## [0.26.0] - 2026-08-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.26.0"
+version = "0.27.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), opencode, and Kimi Code CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read

--- a/src/klaussy/cli.py
+++ b/src/klaussy/cli.py
@@ -20,6 +20,7 @@ from klaussy.import_lint import scan_paths as scan_imports
 from klaussy.pr_template import scaffold_pr_template
 from klaussy.review_prep import prepare_review, render_dict, render_markdown
 from klaussy.secret_scan import scan_paths as scan_secrets
+from klaussy.skills import HUMANIZE_BLOCK
 from klaussy.split_prep import prepare_split
 from klaussy.split_prep import render_dict as render_split_dict
 from klaussy.split_prep import render_markdown as render_split_markdown
@@ -279,13 +280,24 @@ def humanize(
     check: bool = typer.Option(
         False, "--check", help="Exit 1 if any file would change; don't modify."
     ),
+    rules: bool = typer.Option(
+        False, "--rules", help="Print the prompt-side humanization rules and exit."
+    ),
 ) -> None:
     """Deterministically humanize prose (strip AI tells), preserving all code.
 
     The canonical scrubber shared with klaussy-desktop. With no files it reads
     stdin and writes the result to stdout — so other tools can pipe through it
     (e.g. `printf '%s' "$comment" | klaussy humanize`).
+
+    `--rules` prints the prompt-side block instead of scrubbing. The scrubber is
+    a conservative subset of it, so a tool that builds its own review prompt can
+    embed these rules rather than maintaining a copy that drifts.
     """
+    if rules:
+        sys.stdout.write(HUMANIZE_BLOCK + "\n")
+        return
+
     if not files:
         sys.stdout.write(humanize_text(sys.stdin.read()))
         return

--- a/src/klaussy/humanize.py
+++ b/src/klaussy/humanize.py
@@ -43,7 +43,7 @@ _OPENERS = (
 _SCAFFOLD = (
     r"(?:Let me know if[^\n]*|Hope (?:this|that) helps[^\n]*"
     r"|I hope (?:this|that) helps[^\n]*|Feel free to[^\n]*"
-    r"|Happy to help[^\n]*|Let me know your thoughts[^\n]*)"
+    r"|(?:I'?m )?[Hh]appy to [^\n]*|Let me know your thoughts[^\n]*)"
 )
 
 # Thanking bots for review or comments. Stripped at the start of the text or a line.
@@ -139,7 +139,28 @@ def _match_case(matched: str, replacement: str) -> str:
     return replacement
 
 
+# Cap on the fixed-point loop below. Every rule only deletes or shortens, so the
+# text always converges; the cap just bounds a pathological input.
+_MAX_PASSES = 5
+
+
 def _scrub_prose(s: str) -> str:
+    """Scrub until the text stops changing.
+
+    Each rule strips one leading tell, which can expose another: "It's worth
+    noting that actually X" loses the opener and is left starting with
+    "Actually". A single pass would hand that back to the caller, so callers had
+    to run the scrubber twice to get a clean result.
+    """
+    for _ in range(_MAX_PASSES):
+        scrubbed = _scrub_once(s)
+        if scrubbed == s:
+            return s
+        s = scrubbed
+    return s
+
+
+def _scrub_once(s: str) -> str:
     # Em / en dashes — the single strongest tell. A dash between two numbers is a
     # range ("35–50 min"), so it collapses to a plain hyphen; spacing it out would
     # read as a subtraction or a dropped clause.

--- a/src/klaussy/skills.py
+++ b/src/klaussy/skills.py
@@ -73,7 +73,10 @@ HUMANIZE_BLOCK = "\n".join(
         " Use a comma or rewrite the sentence. That one tell gives the game away"
         " faster than everything below it combined.",
         "",
-        "**Voice: say it out loud.**",
+        "**Voice: say it out loud.** The target is a competent engineer typing"
+        " this once, in a hurry, who isn't going to read it back. Not a careful"
+        " writer, not a summary of the facts: a person with an opinion who wants"
+        " to get on with their day.",
         "",
         "- **Write what you'd say standing at their desk.** If you wouldn't say the"
         " sentence to a colleague, don't write it. That one test catches most of"
@@ -97,8 +100,24 @@ HUMANIZE_BLOCK = "\n".join(
         ' maintainable"). Pick the word that carries the point.',
         '- **Don\'t announce structure.** No "There are three issues here:", no'
         ' "Let me walk through this". Say the thing.',
-        "- **Vary sentence shape.** Don't open every line the same way, and don't"
-        " land on the same length every time.",
+        "- **Type it once and don't polish it.** The last tell isn't a wrong"
+        " word, it's evenness: every sentence complete, every paragraph the same"
+        " shape, every point covered in order. Let it be uneven. A long sentence"
+        " next to a three-word one. Two points where a tidy version would make"
+        " four.",
+        '- **Have a stance.** "I\'d drop this", "no idea why this is here",'
+        ' "this\'ll fall over under load". First person and an opinion read as a'
+        " person; an even, neutral summary reads as generated, however short it"
+        " is.",
+        "- **Skip the obvious.** A lazy writer leaves out what the reader can"
+        " already see and doesn't round the thought off. \"Tests cover the happy"
+        ' path and the concurrent case" is "tests for both". What it never drops'
+        " is the thing being talked about: keep the nouns that carry the"
+        ' meaning ("we invalidated the cache on every write", not "we invalidated'
+        ' on every write"). Being lazy costs the reader nothing they needed.',
+        "- **Don't mirror the source.** Same facts, your own shape: merge its"
+        " paragraphs, reorder them, drop a section that isn't worth its space."
+        " Keep every noun that carries meaning while you do it.",
         "",
         "**Shape: the smallest thing that carries the point.**",
         "",
@@ -140,49 +159,45 @@ HUMANIZE_BLOCK = "\n".join(
         " reconstructable prose, and cutting it costs the reader a trip back to the"
         " code. Trim the sentences around them, keep them.",
         "",
-        "**Don't (the tells; klaussy's scrubber catches a subset of these):**",
+        "**Answer what was asked, then stop.** Padding is the tell that survives"
+        " every style fix, and it takes three shapes. All three are cuts, not"
+        " rewrites:",
         "",
-        '- **No filler openers.** Cut "It\'s worth noting that", "It\'s important to'
-        ' note that", "I noticed that", "I wanted to point out that", "Please'
-        ' note that", "Just to mention", "Worth noting", "Note that". State'
-        " the point directly.",
-        '- **No chatbot scaffolding.** No "Let me know if...", "Hope this helps",'
-        ' "Feel free to...", "Happy to help", "Let me know your thoughts".',
-        '- **Never use "actual" or "actually", and don\'t swap in "real",'
-        ' "really", "genuinely", or "truly".** All of them are empty emphasis:'
-        ' "it actually works" is "it works", "the actual value" is "the value",'
-        ' "real work" is "work". Delete the word. If the sentence needs a'
-        ' contrast, name it ("the value on disk, not the cached one"), and keep'
-        ' "real" only where it draws a distinction the reader can\'t infer'
-        ' ("real user data, not fixtures").',
-        '- **Tighten hedges.** "in order to" → "to"; "could potentially"'
-        ' → "could"; "may potentially" → "may". Drop stacked'
-        " qualifiers.",
-        '- **No emoji, no exclamatory enthusiasm, no "Certainly"/"Great question".**',
-        '- **No excessive apologies.** Avoid apologetic filler ("Sorry about'
-        ' that!", "My apologies for the confusion", "Apologies for the'
-        ' oversight"). State the correction or resolution directly.',
-        '- **No passive suggestions.** "Check whether the user is admin" and'
-        ' "rename foo to bar", not "it would be good to check..." or "you might'
-        ' want to rename...".',
-        "- **No LLM lexicon.** Don't use *delve, tapestry, realm, landscape,"
-        " journey, navigate, leverage, utilize, robust, seamless, elevate, unlock,"
-        " foster, underscore, paradigm*.",
-        "- **No transition crutches** (*furthermore, moreover, additionally,"
-        " consequently, nevertheless, in conclusion*). Cut them or use the plain"
-        " one.",
-        '- **No rhetorical reframes.** No negation-reframe ("not only... but also",'
-        " \"this isn't just a bug fix, it's...\") and no standalone summary lines"
-        ' ("And that\'s the whole point.").',
-        '- **No praise, ranking, or thanking a bot.** Cut "great catch", "nice'
-        ' find", "excellent point", "the sharpest catch in the review". Rating a'
-        " comment against the others says nothing about the code. When the reviewer"
-        " is a bot, another agent, or a CI check, answer the substance with no"
-        " pleasantries at all.",
+        "- **No closing principle.** Don't end by restating your decision as a"
+        " general rule (\"I'd still reach for an iframe when you want a separate"
+        ' document context for third-party code"). It answers nothing about this'
+        " change and only validates the view you already gave. Stop at the last"
+        " concrete point.",
+        "- **No mechanism they didn't ask for.** Explaining how the thing works,"
+        " in terms only you are holding in your head, reads as padding even to the"
+        " person who wrote the code. If a paragraph doesn't change what the reader"
+        " does next, cut it. When they need it, they'll ask.",
+        "- **Grant a point in four words, or not at all.** Where the other person"
+        " is right about something, say so and move on: \"Yes, Shadow DOM wouldn't"
+        ' need the ResizeObserver" beats "the ResizeObserver cost is real and'
+        " Shadow DOM wouldn't pay it\". Dressing agreement up in a metaphor is the"
+        " most AI-sounding sentence in most replies. Never manufacture the"
+        " agreement, though: if the author's answer is no, it stays no, and you"
+        " don't go looking for something to validate on the way there.",
+        "",
+        "**Don't (mechanical tells).** klaussy's scrubber deletes these"
+        " deterministically after you write, so don't spend attention on them:"
+        " filler openers, chatbot scaffolding, apologies, praise or thanking a"
+        " bot, *actual/actually*, *in order to*, *could/may potentially*,"
+        ' *utilize/leverage*, *prior to*, emoji, and "Certainly"/"Great'
+        " question\". Two the scrubber can't catch, so they're on you:"
+        " **no LLM lexicon** (*delve, tapestry, realm, landscape, journey,"
+        " navigate, robust, seamless, elevate, unlock, foster, underscore,"
+        ' paradigm*) and **no rhetorical reframes** ("not only... but also",'
+        ' "this isn\'t just a bug fix, it\'s...", or a smug standalone like "And'
+        " that's the whole point.\").",
         '- **No invented consensus.** No "most people expect this", "everyone does'
         ' it this way", "nobody reads these logs", "it\'s widely considered best'
         " practice\". Argue from the code, the repo's own conventions, or a"
         ' linkable source, or own it as your view ("I\'d expect X here").',
+        '- **No passive suggestions.** "Check whether the user is admin" and'
+        ' "rename foo to bar", not "it would be good to check..." or "you might'
+        ' want to rename...".',
         "- **Never reword code**, identifiers, or anything inside backticks or"
         " fences. Humanize prose only.",
         "",
@@ -227,6 +242,22 @@ HUMANIZE_BLOCK = "\n".join(
         "",
         "> Human: The retry loop eats the 429, so a rate-limited call comes back"
         " looking fine. Rethrow after the last attempt.",
+        "",
+        "**Tell-free but still generated, then written by a person.** Both say the"
+        " same thing. The first is even: three paragraphs of the same shape, every"
+        " sentence complete, no one behind it.",
+        "",
+        "> Tidy: The caching layer now uses a shared in-memory cache instead of a"
+        " per-request database query, cutting the load on the primary instance."
+        " The cache populates on first access and invalidates when the underlying"
+        " record changes. This also fixes a subtle race condition where two"
+        " simultaneous requests could both populate the same entry. Tests cover"
+        " both the happy path and concurrent access.",
+        "",
+        "> Human: Swapped the per-request query for one shared cache, so the"
+        " primary isn't getting hammered. Fills on first read, drops when the"
+        " record changes. Also kills a race where two requests could populate the"
+        " same key, there's a per-key lock now. Tests for both.",
     ]
 )
 

--- a/src/klaussy/templates/skills/humanize/SKILL.md
+++ b/src/klaussy/templates/skills/humanize/SKILL.md
@@ -14,17 +14,54 @@ If `$ARGUMENTS` is empty, humanize the prose the user pasted into the conversati
 
 ## Steps
 
-1. **Get the prose.** For file targets, Read each file. For pasted text, work with what's in the conversation. If the text is a reply inside a thread (a review comment, a message chain), the surrounding comments are read-only context: take their substance, neutralize their tone in your head, and humanize only your own message. Don't carry the thread's bluntness or rudeness into what you write — see "Don't mirror the thread's tone" above.
-2. **Rewrite by the rules above.** This is the judgment pass, and it has two halves. *Voice*: read each sentence as if you were saying it out loud to a colleague, then write that version. Contractions in, noun phrases back into verbs ("performs validation of" is "validates"), plain short words, a named subject doing the work. *Cutting*: kill filler openers, drop chatbot scaffolding, replace em/en dashes, tighten hedges, cut empty emphasis (*actual*, *actually*, *real*, *really*, *truly*), strip structure the text is too short to need. Only touch prose, never code, identifiers, or anything inside backticks or fences.
-3. **Run the deterministic backstop.** klaussy ships a code-preserving scrubber that guarantees the high-confidence tells are gone regardless of the rewrite. This is the post-processing step, always run it last:
-   - **Files:** `klaussy humanize <file>... --write` (rewrites in place; prints which files changed).
-   - **Pasted text:** pipe the rewritten text into `klaussy humanize` on stdin and use its output (on macOS/Linux, e.g. `printf '%s' "$text" | klaussy humanize`; on Windows use the shell's own piping — the point is stdin in, humanized text out).
-   - If the `klaussy` CLI isn't on PATH, run it via `python -m klaussy humanize ...`. If neither resolves, say the deterministic backstop was unavailable and that only the rewrite was applied.
-4. **Report** what changed: for files, the list the scrubber reported; for text, show the humanized result.
+**Get the prose first.** For file targets, Read each file. For pasted text, work with what's in the conversation. If the text is a reply inside a thread (a review comment, a message chain), the surrounding comments are read-only context: take their substance, neutralize their tone in your head, and humanize only your own message. Don't carry the thread's bluntness or rudeness into what you write — see "Don't mirror the thread's tone" above.
+
+Then run four passes, in this order, each as its own turn. Doing it in one pass is what makes the output read like a tidied-up model draft: with every rule in play at once, the ones that survive are the safe mechanical ones, and voice and length lose. **One job per pass. Do not do a later pass's job early.**
+
+### Pass 1 — Cut (content only, no restyling)
+
+Rules that apply: **Answer what was asked, then stop** and **Shape**, above. Nothing else.
+
+Delete whole sentences and paragraphs that don't earn their place: the closing principle, the mechanism nobody asked about, the point already made, the summary of what you just said. **Keep every sentence you keep word for word.** If you find yourself improving a sentence, stop — that's pass 2.
+
+For a reply, the question being answered is the yardstick. Write it down first if it isn't obvious, then cut anything that doesn't answer it.
+
+### Pass 2 — Voice (register only, no content change)
+
+Rules that apply: **Voice** and **Stay civil while you cut**, above. Nothing else.
+
+Say each line out loud and write that version. Contractions in, noun phrases back into verbs, plain short words, a named subject doing the work, a stance where there is one. Fragments are fine. Let the rhythm be uneven.
+
+**Every fact that goes into this pass comes out of it.** No new claims, none dropped, none softened or strengthened. If a sentence seems worth deleting here, you missed it in pass 1; leave it.
+
+### Pass 3 — Check (did the meaning survive?)
+
+Put the pass 2 output next to the original and compare claim by claim:
+
+- **Added** — anything asserted that the original didn't say, including a hedge that became a certainty, or agreement the author never gave.
+- **Dropped** — a load-bearing noun, number, identifier, file path, or version. "We invalidated on every write" lost `the cache`, and that's a failure even though it reads fine.
+- **Reversed** — a concession that became a refusal, "may race" that became "races", or a point that changed sides.
+
+Fix what you find by restoring the original's meaning in the pass 2 voice. State plainly what you restored. If nothing changed meaning, say that in one line and move on.
+
+### Pass 4 — Scrub (deterministic backstop)
+
+klaussy ships a code-preserving scrubber that guarantees the high-confidence tells are gone regardless of the rewrite. Always run it last:
+
+- **Files:** `klaussy humanize <file>... --write` (rewrites in place; prints which files changed).
+- **Pasted text:** pipe the pass 3 output into `klaussy humanize` on stdin and use its output (on macOS/Linux, e.g. `printf '%s' "$text" | klaussy humanize`; on Windows use the shell's own piping — the point is stdin in, humanized text out).
+- If the `klaussy` CLI isn't on PATH, run it via `python -m klaussy humanize ...`. If neither resolves, say the deterministic backstop was unavailable and that only the rewrite was applied.
+
+Then **report** what changed: for files, the list the scrubber reported; for text, show the humanized result.
+
+### When one pass is enough
+
+A single sentence or a one-line comment doesn't need four turns. Below roughly 40 words there's nothing to cut and no structure to break, so do pass 2 and pass 4 and say you skipped the rest. Everything longer gets all four.
 
 ## Rules
 
 - The deterministic scrubber is a conservative subset (dashes, a fixed set of openers/scaffolding, a few hedges, *actual*/*actually*). Your rewrite does the broader work the scrubber can't; the scrubber then guarantees the conservative tells. Run both, not just one.
+- Don't collapse the passes to save a turn. Cutting and restyling in one go is how a rewrite ends up neither shorter nor more human, and merging the check into the voice pass means the pass that changed the meaning is the one grading it.
 - Appeals to consensus ("most people expect...", "everyone does it this way") are a rewrite-only fix too. Don't just soften them into "many teams" — either cite what the claim rests on (the code, a repo convention, a link) or make it your own view. Dropping the claim entirely is fine when the sentence stands without it.
 - *real*, *really*, *genuinely*, and *truly* are the rewrite's job, not the scrubber's — it leaves them alone because "real user data" sometimes contrasts with fixtures. Cut them where they only add emphasis ("real work" is "work"), keep them where they carry that contrast.
 - Preserve the decision and its rationale; never reverse, add, or invent meaning. Humanizing is mostly a tone/style edit, but brevity may drop low-value detail (explanatory parentheticals, restated identifiers, narration the diff already shows). Keep the load-bearing facts, cut what the reader can reconstruct (see "Cut detail, not just words" above).

--- a/tests/evals/test_address_review_eval.py
+++ b/tests/evals/test_address_review_eval.py
@@ -1,0 +1,93 @@
+"""Eval: replies to PR review feedback stay short, civil, and specific.
+
+The address-review skill drafts a reply per review comment. Those replies are
+the most-read prose klaussy produces and the easiest place to sound like a bot:
+thanking a review bot, mirroring a blunt reviewer, or padding a one-line "fixed
+it" into a paragraph. This runs the shipped skill spec against real-shaped
+comments and asserts the properties the humanize block promises.
+
+See harness.py for gating (opt-in, needs the claude CLI).
+"""
+
+from __future__ import annotations
+
+import harness
+import pytest
+
+from klaussy.humanize import humanize
+
+REPLY_INSTRUCTION = (
+    "You have already made the code change described under 'What you did'. "
+    "Draft ONLY the reply you will post in this review thread. No preamble, no "
+    "explanation of your process, just the reply text."
+)
+
+# (label, review comment, what the author did, forbidden, required, max_sentences)
+FIXTURES = [
+    (
+        "bot-reviewer",
+        "**coderabbitai[bot]** commented on `src/api/session.py:88`:\n"
+        "> The `retry` helper catches `HTTPError` but never re-raises after the "
+        "final attempt, so a rate-limited call returns `None` to the caller.",
+        "Re-raised the exception after the last attempt and added a test for the 429 path.",
+        ["thanks", "thank you", "good catch", "great catch", "appreciate"],
+        ["rethrow", "re-rais", "raise"],
+        2,
+    ),
+    (
+        "blunt-human",
+        "@marco commented on `src/jobs/export.py:212`:\n"
+        "> This is sloppy. Did you even run it once? The cleanup is not awaited "
+        "so the temp dir is gone before the write finishes. Obviously broken.",
+        "Awaited the cleanup coroutine after the writes complete.",
+        ["sloppy", "obviously", "did you even", "sorry about that", "my apologies"],
+        ["await"],
+        2,
+    ),
+    (
+        "declining-out-of-scope",
+        "@priya commented on `src/klaussy/humanize.py:40`:\n"
+        "> While you're in here, can you also switch the whole module to use "
+        "compiled regex constants and add type annotations throughout?",
+        "Nothing. This is out of scope for a bug-fix PR that touches four lines, "
+        "and the module already compiles its patterns at import time.",
+        ["nobody asked", "wasn't asked for", "out of nowhere", "why is this here"],
+        ["scope", "separate", "follow"],
+        3,
+    ),
+    (
+        "simple-accept",
+        "@dana commented on `README.md:114`:\n> typo: 'scubber' -> 'scrubber'",
+        "Fixed the typo.",
+        ["thanks for", "hope this helps", "let me know", "great catch"],
+        ["fix", "typo", "scrubber"],
+        1,
+    ),
+]
+
+
+@harness.requires_eval_env
+@pytest.mark.parametrize(
+    "label,comment,did,forbidden,required,max_sentences",
+    FIXTURES,
+    ids=[f[0] for f in FIXTURES],
+)
+def test_reply_is_short_civil_and_specific(label, comment, did, forbidden, required, max_sentences):
+    context = f"Review comment:\n{comment}\n\nWhat you did:\n{did}"
+    out = harness.run_skill("address-review", context, instruction=REPLY_INSTRUCTION)
+    low = out.lower()
+
+    for bad in forbidden:
+        assert bad.lower() not in low, f"[{label}] said {bad!r}: {out!r}"
+    assert any(need in low for need in required), (
+        f"[{label}] none of {required} in the reply: {out!r}"
+    )
+
+    n = harness.count_sentences(out)
+    assert n <= max_sentences, f"[{label}] {n} sentences, budget {max_sentences}: {out!r}"
+
+    phrase_tells = [t for t in harness.ai_tells_present(out) if t != "—"]
+    assert not phrase_tells, f"[{label}] phrase tells: {phrase_tells}: {out!r}"
+    assert not harness.ai_tells_present(humanize(out)), (
+        f"[{label}] tells survive the scrubber: {out!r}"
+    )

--- a/tests/evals/test_humanize_longform_eval.py
+++ b/tests/evals/test_humanize_longform_eval.py
@@ -1,0 +1,116 @@
+"""Eval: a long technical reply survives humanizing, short and intact.
+
+The short fixtures in test_humanize_eval.py all pass and always did; the failures
+only show up on the shape this covers, a several-hundred-word reply arguing a
+position over multiple points. Single-pass humanizing left those at ~50% of the
+original length, mirrored the draft's paragraph count, and produced no fragments;
+the four-pass flow in the humanize skill is what this measures. The fixture is
+deliberately generic so no real pull request lands in a public repo.
+"""
+
+from __future__ import annotations
+
+import harness
+import pytest
+
+from klaussy.humanize import humanize
+
+QUESTION = (
+    "Have you considered just using a database transaction here? I'd expect it to "
+    "be simpler than the queue you've added, and it wouldn't need the reconciler."
+)
+
+DRAFT = """\
+Here's a draft reply you can post in the review thread:
+
+---
+
+Great question, and a transaction was the first thing I reached for. The short
+version is that it doesn't cover what needs covering here, and I'll walk through
+the two cases where it falls short.
+
+**The write spans two datastores.** The order row lives in Postgres, but the
+inventory decrement happens in the Redis counter that the storefront reads from.
+A Postgres transaction can roll back the order row, but it has no way to roll
+back the Redis write — so a failure between the two leaves us with decremented
+inventory and no order, which is exactly the state we're trying to make
+impossible.
+
+**The downstream call is not idempotent.** The payment capture is an HTTP request
+to a third party, and it is important to note that a transaction cannot be held
+open across that call without pinning a connection for the duration. Under load
+that exhausts the pool, which is the failure mode we hit in the incident on the
+14th.
+
+There's also a subtle wrinkle around retries: because the capture can succeed and
+then time out, we need a durable record that the attempt happened before we make
+it. A transaction that rolls back destroys precisely the record we would need to
+reconcile against.
+
+You're right that the reconciler is a cost a transaction wouldn't pay — it's an
+extra moving part and it needs monitoring. That's a fair tradeoff to raise. But
+given the two issues above I don't think it tips the balance.
+
+Happy to walk through a hybrid where the Postgres write stays transactional and
+only the cross-store step goes through the queue, if you think there's something
+I'm missing here. My general view is that a queue is the right primitive whenever
+a write has to span two systems that can't participate in the same transaction.
+"""
+
+INSTRUCTION = (
+    "Humanize this reply, which will be posted in a PR review thread. "
+    "Output ONLY the final humanized reply."
+)
+
+# The reply is the answer to this, and pass 1 cuts against it. Without the
+# question in context there is no yardstick for what fails to earn its place,
+# and the cut pass leaves the draft's shape nearly intact.
+CONTEXT = f"The reviewer asked:\n{QUESTION}\n\nThe draft reply to humanize:\n{DRAFT}"
+
+# Facts the reply argues from. Losing one means the rewrite dropped a load-bearing
+# noun or number, which the check pass exists to catch.
+MUST_SURVIVE = ["redis", "postgres", "captur", "reconcil"]
+
+# Padding the draft carries that a humanized reply should not.
+MUST_GO = [
+    "here's a draft",
+    "great question",
+    "it is important to note",
+    "happy to walk",
+    "my general view",
+    "the short version is",
+]
+
+
+@harness.requires_eval_env
+@pytest.mark.parametrize("run", [1, 2])
+def test_long_reply_gets_short_without_losing_the_argument(run):
+    out = humanize(harness.run_skill("humanize", CONTEXT, instruction=INSTRUCTION, timeout=600))
+    low = out.lower()
+
+    for gone in MUST_GO:
+        assert gone not in low, f"kept padding {gone!r}: {out!r}"
+    for kept in MUST_SURVIVE:
+        assert kept in low, f"dropped substance {kept!r}: {out!r}"
+
+    # Guard, not a quality bar: four passes land at 120-167 on this 330-word
+    # draft, a single tidy-up pass nearer 200.
+    words = len(out.split())
+    assert words <= 175, f"{words} words, expected the four-pass flow to cut harder: {out!r}"
+
+    assert not harness.ai_tells_present(out), f"tells survived: {harness.ai_tells_present(out)}"
+
+
+@harness.requires_eval_env
+def test_the_concession_is_granted_not_inflated():
+    """The reviewer is right about the reconciler, so the reply says so briefly.
+
+    "a cost a transaction wouldn't pay" is the dressed-up form that kept coming
+    back; granting the point in a few plain words is the target.
+    """
+    out = humanize(harness.run_skill("humanize", CONTEXT, instruction=INSTRUCTION, timeout=600))
+    low = out.lower()
+
+    assert "reconcil" in low, f"dropped the reconciler point entirely: {out!r}"
+    assert "wouldn't pay" not in low, f"kept the dressed-up concession: {out!r}"
+    assert "cuts both ways" not in low, f"kept the stock metaphor: {out!r}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1575,6 +1575,32 @@ class TestHumanizeScrubber:
         assert humanize("parses take 35–50 min") == "parses take 35-50 min"
         assert humanize("pages 3—4 are wrong") == "pages 3-4 are wrong"
 
+    def test_stacked_tells_clear_in_one_run(self):
+        """Stripping one tell can expose the next; one run must catch them all.
+
+        Each rule only matches at the start of a line, so removing an opener
+        promotes whatever followed it to line-initial. Before the scrubber
+        iterated to a fixed point, callers had to run it twice.
+        """
+        from klaussy.humanize import humanize
+
+        assert humanize("It's worth noting that actually the loop leaks.") == "The loop leaks."
+        assert humanize("Great catch. Nice find. This leaks.") == "This leaks."
+        assert humanize("Personally, honestly, this is wrong.") == "This is wrong."
+        assert humanize("Thanks @dependabot! Great catch, this races.") == "This races."
+
+    def test_is_idempotent(self):
+        from klaussy.humanize import humanize
+
+        for text in [
+            "It is worth noting that furthermore this races.",
+            "Note that it is worth noting that this leaks.",
+            "Use `a — b` then:\n```\nx — y\n```\nbut this — changes.",
+            "Nit: rename foo to bar.",
+        ]:
+            once = humanize(text)
+            assert humanize(once) == once, f"second run changed {text!r}"
+
     def test_strips_leading_filler_opener_and_recapitalizes(self):
         from klaussy.humanize import humanize
 
@@ -1590,6 +1616,17 @@ class TestHumanizeScrubber:
             humanize("This races on startup.\nLet me know if you have questions!")
             == "This races on startup."
         )
+
+    def test_drops_happy_to_offers_beyond_happy_to_help(self):
+        """ "Happy to help" was the only variant matched, so offers like "happy to
+        dig into X" survived a review reply."""
+        from klaussy.humanize import humanize
+
+        assert humanize("Rethrown now.\nHappy to dig into a hybrid if I missed one.") == (
+            "Rethrown now."
+        )
+        # Mid-sentence "happy to" is ordinary prose, not a sign-off.
+        assert humanize("She was happy to see it land.") == "She was happy to see it land."
 
     def test_tightens_verbose_phrasings(self):
         from klaussy.humanize import humanize
@@ -1618,6 +1655,23 @@ class TestHumanizeScrubber:
 
 
 class TestHumanizeCli:
+    def test_rules_prints_the_shared_block(self):
+        """`--rules` is how another tool embeds the prompt-side rules.
+
+        klaussy-desktop builds its own review prompt when a worktree has no
+        scaffolded skill; without this it hand-maintained a copy that drifted.
+        """
+        from klaussy.skills import HUMANIZE_BLOCK
+
+        result = runner.invoke(app, ["humanize", "--rules"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == HUMANIZE_BLOCK.strip()
+
+    def test_rules_does_not_read_stdin(self):
+        result = runner.invoke(app, ["humanize", "--rules"], input="Fix this — now.")
+        assert result.exit_code == 0
+        assert "Fix this" not in result.stdout
+
     def test_stdin_to_stdout(self):
         result = runner.invoke(app, ["humanize"], input="Fix this — now.")
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

The humanize skill now runs in four passes instead of one, because tuning the shared block had stopped working. Also fixes the scrubber needing two runs to converge, adds `klaussy humanize --rules`, and adds evals for the two surfaces where the failures actually live.

## Changes

**Four passes.** Cut (content only, keeping every retained sentence word for word), voice (register only, facts frozen), check (did the meaning survive), then the deterministic scrubber. Each pass carries only its own sections of the block. On a 330-word technical reply that lands at 120-167 words with fragments and a stance, where the single pass sat near 200 and mirrored the draft's paragraph count. Below ~40 words it runs voice and scrub only and says so.

**Why split it.** Two rule additions in a row measured as net-negative. A guard against dropping load-bearing nouns didn't take and cost a dropped noun anyway; a rule aimed at one specific paragraph moved it 0 times in 6 attempts across two phrasings, while making replies longer and doubling the exact phrasing it was meant to kill. At 24 bullets the block is at capacity and rule 25 degrades compliance with the rest.

**The check pass.** Splitting cut from voice means neither pass verifies the claims survived, so the third diffs the rewrite against the original for anything added (including agreement the author never gave), dropped (a load-bearing noun, number, identifier, path), or reversed. Both failure modes were measured before it existed: a rewrite that turned "we invalidated the cache on every write" into "we invalidated on every write", and one that inverted a concession.

**The block traded eleven bullets for three sections.** Mechanical tells the scrubber deletes deterministically now point at the scrubber in one line, freeing attention for what a model has to judge: a Voice section aimed at "a competent engineer typing this once, in a hurry, who isn't going to read it back", and an "Answer what was asked, then stop" section covering the closing principle, the mechanism nobody asked for, and granting a point without inflating it.

**Scrubber reaches a fixed point.** Every rule matches at the start of a line, so removing one tell promoted the next into that position where nothing re-examined it. "It's worth noting that actually the loop leaks" needed a second run to lose "Actually"; 7 of 8 sampled inputs did. It now iterates until stable.

**`klaussy humanize --rules`** prints the prompt-side block, so klaussy-desktop can embed current rules instead of maintaining a copy that drifts.

## Test Plan

- [x] Tests pass locally — 740 unit tests, ruff check, ruff format
- [x] Manually verified

Evals (opt-in, `KLAUSSY_RUN_EVALS=1`) grew from one humanize file to three. `test_address_review_eval.py` covers replies to review feedback — a review bot, a hostile reviewer, a request worth declining, a one-word fix — and passed 12/12 across three runs. `test_humanize_longform_eval.py` covers the shape that was actually failing: every previously checked-in fixture was short, and short prose always passed.

Its word budget is documented as a regression guard rather than a quality bar, after an earlier threshold sat on the distribution's edge and failed 1-in-2 runs on a six-word margin.

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [x] Documentation updated if needed

## Notes

Version bumped to 0.27.0 with a CHANGELOG entry, since scaffolded repos only pick this up on a version change.

Pairs with steph-dove/klaussy-desktop#52, which runs these passes from the app, and #48, which brings the desktop's JS port of the scrubber back in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
