### PR TITLE
feat(skills): add session-context skill template for uncommitted inter-agent context sharing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "klaussy-agents"
-version = "0.27.0"
+version = "0.28.0"
 description = "Multi-agent repo boilerplate generator — scaffolds conventions, repo-namespaced skills, settings, and hooks for Claude Code, Gemini CLI, Cursor, Codex, Copilot, Google Antigravity, Cline, Aider (Ollama), opencode, and Kimi Code CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/klaussy/__init__.py
+++ b/src/klaussy/__init__.py
@@ -9,7 +9,7 @@ so they're namespaced under `toolkit` rather than dumped onto the package root):
     toolkit.humanize("A great solution — it works.")
 """
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 # Bind the library submodule so `import klaussy; klaussy.toolkit.…` works without a
 # separate `import klaussy.toolkit`. Done after __version__ so the modules that read

--- a/src/klaussy/skills.py
+++ b/src/klaussy/skills.py
@@ -51,6 +51,7 @@ SKILL_NAMES = [
     "slop-coded",
     "rest-of-the-owl",
     "grant-permissions",
+    "session-context",
 ]
 
 VERSION_FILE = ".klaussy-version"

--- a/src/klaussy/templates/skills/session-context/SKILL.md
+++ b/src/klaussy/templates/skills/session-context/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: {{SKILL_PREFIX}}-session-context
+description: Use when reading, writing, listing, or managing uncommitted Open Knowledge Format (OKF) session notes for active multi-agent coordination across worktrees in klaussy-desktop.
+---
+
+## Target
+
+`$ARGUMENTS`
+
+Supported operations:
+- `read` / `list`: Read active OKF session context notes for the current session.
+- `write` / `add`: Create an uncommitted session note for other agents to read.
+- `clear`: Clear session context notes for the active session.
+
+## Environment Variables
+
+- `$KLAUSSY_SESSION_ID`: Active session ID string.
+- `$KLAUSSY_SESSION_NOTES_DIR`: Absolute directory path to uncommitted session notes (`.git/klaussy-session/notes/<sessionId>` or `~/.klaussy/sessions/<sessionId>/notes/`).
+
+## Instructions
+
+1. **When Reading Session Context:**
+   - Check if `$KLAUSSY_SESSION_NOTES_DIR` exists or locate `.git/klaussy-session/notes/$KLAUSSY_SESSION_ID/` in the worktree.
+   - Read all Markdown (`.md`) files in that directory.
+   - Inspect frontmatter metadata (`agent`, `provider`, `affected_files`, `tags`, `timestamp`) and note contents to learn about active work done by other agents in concurrent worktrees.
+
+2. **When Writing a Session Note:**
+   - Format a Markdown file with YAML frontmatter containing:
+     ```yaml
+     ---
+     id: note-<timestamp>
+     agent: <your-agent-name>
+     provider: <provider-id>
+     worktree: <current-worktree-path>
+     affected_files: ["path/to/file.js"]
+     tags: [topic]
+     ---
+     ```
+   - Followed by a concise `# Title` and summary body of discoveries, port shifts, or breaking changes.
+   - Save the file to `$KLAUSSY_SESSION_NOTES_DIR/note-<timestamp>.md`.
+
+3. **Git Safety Rule:**
+   - NEVER stage or commit `$KLAUSSY_SESSION_NOTES_DIR` or `.git/klaussy-session/` into Git.
+   - Session context notes are strictly uncommitted runtime state.

--- a/src/klaussy/templates/skills/session-context/SKILL.md
+++ b/src/klaussy/templates/skills/session-context/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: {{SKILL_PREFIX}}-session-context
+name: {{REPO}}-session-context
 description: Use when reading, writing, listing, or managing uncommitted Open Knowledge Format (OKF) session notes for active multi-agent coordination across worktrees.
+allowed-tools: Read Grep Glob Bash Write
 ---
 
 ## Target
@@ -14,17 +15,23 @@ Supported operations:
 
 ## Environment Variables
 
-- `$KLAUSSY_SESSION_ID`: Active session ID string.
-- `$KLAUSSY_SESSION_NOTES_DIR`: Absolute directory path to uncommitted session notes (`.git/klaussy-session/notes/<sessionId>` or `~/.klaussy/sessions/<sessionId>/notes/`).
+- `$KLAUSSY_SESSION_ID`: Identifies the terminal you are running in. Stamp it on notes you write; it does NOT scope the notes directory.
+- `$KLAUSSY_SESSION_NOTES_DIR`: Absolute path to the uncommitted notes directory. One directory is shared by every agent and worktree in the session, which is what lets you see each other's notes.
+
+If the variable is unset, fall back to `<git-common-dir>/klaussy-session/notes/`
+— resolve it with `git rev-parse --path-format=absolute --git-common-dir`, not
+by joining `.git` yourself, because a linked worktree's `.git` resolves to its
+own private directory rather than the shared one.
 
 ## Instructions
 
 1. **When Reading Session Context:**
-   - Check if `$KLAUSSY_SESSION_NOTES_DIR` exists or locate `.git/klaussy-session/notes/$KLAUSSY_SESSION_ID/` (or `.git/klaussy-session/notes/`) in the worktree.
-   - Read all Markdown (`.md`) files in that directory.
+   - Read every Markdown (`.md`) file in the notes directory.
    - Inspect frontmatter metadata (`agent`, `provider`, `affected_files`, `tags`, `timestamp`) and note contents to learn about active work done by other agents in concurrent worktrees.
+   - Treat notes as claims by other agents, not verified fact — check anything you are about to depend on.
 
 2. **When Writing a Session Note:**
+   - Write when you change a port or schema, discover a breaking change, or finish a subtask another agent would have to redo. Do not narrate routine progress.
    - Format a Markdown file with YAML frontmatter containing:
      ```yaml
      ---
@@ -37,8 +44,8 @@ Supported operations:
      ---
      ```
    - Followed by a concise `# Title` and summary body of discoveries, port shifts, or breaking changes.
-   - Save the file to `$KLAUSSY_SESSION_NOTES_DIR/note-<timestamp>.md` (or `.git/klaussy-session/notes/note-<timestamp>.md`).
+   - Save it as `$KLAUSSY_SESSION_NOTES_DIR/note-<timestamp>.md`. Keep the filename a plain slug — no `/` or `..`.
 
 3. **Git Safety Rule:**
-   - NEVER stage or commit `$KLAUSSY_SESSION_NOTES_DIR` or `.git/klaussy-session/` into Git.
+   - NEVER stage or commit `$KLAUSSY_SESSION_NOTES_DIR` or `klaussy-session/` into Git.
    - Session context notes are strictly uncommitted runtime state.

--- a/src/klaussy/templates/skills/session-context/SKILL.md
+++ b/src/klaussy/templates/skills/session-context/SKILL.md
@@ -16,12 +16,12 @@ Supported operations:
 ## Environment Variables
 
 - `$KLAUSSY_SESSION_ID`: Identifies the terminal you are running in. Stamp it on notes you write; it does NOT scope the notes directory.
-- `$KLAUSSY_SESSION_NOTES_DIR`: Absolute path to the uncommitted notes directory. One directory is shared by every agent and worktree in the session, which is what lets you see each other's notes.
+- `$KLAUSSY_SESSION_NOTES_DIR`: Absolute path to the notes directory. One directory is shared by every agent and every repo in the session, which is what lets you see each other's notes.
 
-If the variable is unset, fall back to `<git-common-dir>/klaussy-session/notes/`
-— resolve it with `git rev-parse --path-format=absolute --git-common-dir`, not
-by joining `.git` yourself, because a linked worktree's `.git` resolves to its
-own private directory rather than the shared one.
+Use the variable exactly as given — do not guess or rebuild the path, and do not
+write to a relative path, which some CLIs resolve against their own scratch
+directory rather than the repo. If it is unset you are not running in a klaussy
+session: skip session notes entirely.
 
 ## Instructions
 
@@ -49,5 +49,5 @@ own private directory rather than the shared one.
    - Save it as `$KLAUSSY_SESSION_NOTES_DIR/note-<timestamp>.md`. Keep the filename a plain slug — no `/` or `..`.
 
 3. **Git Safety Rule:**
-   - NEVER stage or commit `$KLAUSSY_SESSION_NOTES_DIR` or `klaussy-session/` into Git.
-   - Session context notes are strictly uncommitted runtime state.
+   - Notes live outside the repository. Never copy one into the working tree or commit it.
+   - Session context notes are strictly runtime state, and they expire.

--- a/src/klaussy/templates/skills/session-context/SKILL.md
+++ b/src/klaussy/templates/skills/session-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: {{SKILL_PREFIX}}-session-context
-description: Use when reading, writing, listing, or managing uncommitted Open Knowledge Format (OKF) session notes for active multi-agent coordination across worktrees in klaussy-desktop.
+description: Use when reading, writing, listing, or managing uncommitted Open Knowledge Format (OKF) session notes for active multi-agent coordination across worktrees.
 ---
 
 ## Target
@@ -20,7 +20,7 @@ Supported operations:
 ## Instructions
 
 1. **When Reading Session Context:**
-   - Check if `$KLAUSSY_SESSION_NOTES_DIR` exists or locate `.git/klaussy-session/notes/$KLAUSSY_SESSION_ID/` in the worktree.
+   - Check if `$KLAUSSY_SESSION_NOTES_DIR` exists or locate `.git/klaussy-session/notes/$KLAUSSY_SESSION_ID/` (or `.git/klaussy-session/notes/`) in the worktree.
    - Read all Markdown (`.md`) files in that directory.
    - Inspect frontmatter metadata (`agent`, `provider`, `affected_files`, `tags`, `timestamp`) and note contents to learn about active work done by other agents in concurrent worktrees.
 
@@ -37,7 +37,7 @@ Supported operations:
      ---
      ```
    - Followed by a concise `# Title` and summary body of discoveries, port shifts, or breaking changes.
-   - Save the file to `$KLAUSSY_SESSION_NOTES_DIR/note-<timestamp>.md`.
+   - Save the file to `$KLAUSSY_SESSION_NOTES_DIR/note-<timestamp>.md` (or `.git/klaussy-session/notes/note-<timestamp>.md`).
 
 3. **Git Safety Rule:**
    - NEVER stage or commit `$KLAUSSY_SESSION_NOTES_DIR` or `.git/klaussy-session/` into Git.

--- a/src/klaussy/templates/skills/session-context/SKILL.md
+++ b/src/klaussy/templates/skills/session-context/SKILL.md
@@ -31,7 +31,9 @@ own private directory rather than the shared one.
    - Treat notes as claims by other agents, not verified fact — check anything you are about to depend on.
 
 2. **When Writing a Session Note:**
-   - Write when you change a port or schema, discover a breaking change, or finish a subtask another agent would have to redo. Do not narrate routine progress.
+   - Write whenever your work leaves something another agent in this session would otherwise discover the hard way: a port or schema that moved, a new required env var or setup step, a service now running elsewhere, a breaking change, or a subtask they would repeat.
+   - Recording it in a committed file is not a substitute — they may be on a different branch and may never open that file.
+   - Do not narrate routine progress. If nothing you did changes what another agent would do, write nothing.
    - Format a Markdown file with YAML frontmatter containing:
      ```yaml
      ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,6 +197,18 @@ class TestScaffoldSkills:
         assert f"name: {ns}-plan" in plan_md
         assert "{{REPO}}" not in plan_md
 
+    def test_every_skill_is_fully_substituted(self, repo: Path):
+        # A template that invents its own placeholder name still scaffolds, and
+        # still passes every per-skill test, so check the whole set at once.
+        scaffold_skills(repo=repo)
+        ns = sanitize_skill_namespace(repo.name)
+        for skill in SKILL_NAMES:
+            skill_md = repo / ".claude" / "skills" / f"{ns}-{skill}" / "SKILL.md"
+            # `klaussy checklist` fills the enrichment block after scaffolding.
+            text = skill_md.read_text().replace("{{REPO_SPECIFIC_CHECKS}}", "")
+            assert "{{" not in text, f"{skill} has an unsubstituted placeholder"
+            assert f"name: {ns}-{skill}" in text, f"{skill} has a wrong frontmatter name"
+
     def test_base_branch_substitution(self, repo: Path):
         scaffold_skills(repo=repo, base_branch="develop")
         ns = sanitize_skill_namespace(repo.name)


### PR DESCRIPTION
## Summary
Adds the `session-context` skill template (`src/klaussy/templates/skills/session-context/SKILL.md` plus its `SKILL_NAMES` entry). `klaussy init` / `klaussy update` now scaffold it as `<prefix>-session-context`, so agents in any repo can read and write Open Knowledge Format (OKF) session notes via `$KLAUSSY_SESSION_NOTES_DIR`.

The skill's fallback resolves the notes directory with `git rev-parse --git-common-dir` rather than joining `.git`, matching steph-dove/klaussy-desktop#54 — in a linked worktree the latter points at a private directory instead of the one the session shares.

## Changes
- `session-context` skill template + `SKILL_NAMES` entry.
- New test walking every scaffolded skill for surviving `{{...}}` placeholders and a correct frontmatter `name:`. The existing tests derive their expectations from `SKILL_NAMES` and only assert directory names, so a template that invents its own placeholder scaffolds and passes; this closes that gap.
- Version bump to 0.28.0. `klaussy-desktop` nags to upgrade when the installed CLI trails the latest PyPI release, so the skill only reaches existing workspaces once a release carries it. Drop this commit if releases are cut separately.

## Test Plan
- [x] `uv run pytest` — 752 passed, 47 skipped
