### PR TITLE
fix(session-context): teach agents the one field OKF requires

### DIFF
--- a/src/klaussy/templates/skills/session-context/SKILL.md
+++ b/src/klaussy/templates/skills/session-context/SKILL.md
@@ -27,7 +27,8 @@ session: skip session notes entirely.
 
 1. **When Reading Session Context:**
    - Read every Markdown (`.md`) file in the notes directory.
-   - Inspect frontmatter metadata (`agent`, `provider`, `affected_files`, `tags`, `timestamp`) and note contents to learn about active work done by other agents in concurrent worktrees.
+   - Inspect frontmatter metadata (`agent`, `provider`, `affected_files`, `tags`, `timestamp`, `stale_after`) and note contents to learn about active work done by other agents in concurrent worktrees.
+   - A note whose `stale_after` date has passed is history, not current state; read it, but do not act on it as though it still holds.
    - Treat notes as claims by other agents, not verified fact — check anything you are about to depend on.
 
 2. **When Writing a Session Note:**
@@ -37,6 +38,7 @@ session: skip session notes entirely.
    - Format a Markdown file with YAML frontmatter containing:
      ```yaml
      ---
+     type: session-note
      id: note-<timestamp>
      agent: <your-agent-name>
      provider: <provider-id>
@@ -45,6 +47,7 @@ session: skip session notes entirely.
      tags: [topic]
      ---
      ```
+   - `type` is the one field the Open Knowledge Format requires; keep it as `session-note` so other OKF tooling can read these.
    - Followed by a concise `# Title` and summary body of discoveries, port shifts, or breaking changes.
    - Save it as `$KLAUSSY_SESSION_NOTES_DIR/note-<timestamp>.md`. Keep the filename a plain slug — no `/` or `..`.
 


### PR DESCRIPTION
## Summary

The session-context skill calls these Open Knowledge Format notes, and the frontmatter it told agents to write left out `type`, which [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) names as the only always-required key. Every note written to this template was non-conformant against the spec the skill cites.

Companion to steph-dove/klaussy-desktop#55, which fixes the same gap in the notes klaussy itself writes.

## Changes

- The write template carries `type: session-note`, with a line explaining that it is the one field OKF requires so it survives future edits.
- The reading step lists `stale_after` among the metadata worth inspecting, and tells agents that a note past its expiry is history rather than current state.

## Test Plan

- Template-only change; no code paths touched.
- Applied the same edit to klaussy-desktop's synced copies of this skill and inspected the result there: the yaml block keeps its indentation inside the numbered list, and the new guidance sits with the other read/write instructions. Not scaffolded fresh from this template, so the generator path itself is unverified.

## Checklist

- [x] No code changes
- [x] Equivalent rendered block inspected in a consuming repo
- [ ] Needs a PyPI release for scaffolded repos to pick it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
