### PR TITLE
fix(hooks): make the humanize comment guard actually run

### DIFF
--- a/src/klaussy/_hooklauncher.py
+++ b/src/klaussy/_hooklauncher.py
@@ -13,6 +13,12 @@ guard under the same interpreter klaussy is installed on. `klaussy` is already a
 runtime dependency of the comment/commit guards (they shell out to it), so this
 adds nothing new to install.
 
+`--packaged <name>` runs a guard straight out of the installed klaussy package
+instead of a scaffolded copy. Guards that bake in repo conventions (commit,
+plan-guidance, self-review) must stay per-repo, but the comment humanizer bakes
+in nothing, so running it from the package lets a klaussy-desktop upgrade reach
+every repo at once, including ones klaussy never scaffolded.
+
 `--repo-relative <path>` resolves the guard against the enclosing git repo
 instead of an absolute path. Kimi Code CLI needs it: its hooks live in the user's
 global config, and its four-field `[[hooks]]` schema has no per-OS override or
@@ -49,8 +55,38 @@ def _resolve_in_repo(relpath: str) -> str | None:
     return os.path.join(out.stdout.strip(), relpath)
 
 
+def _run(script: str) -> int:
+    """Execute a guard, propagating its exit code and failing open on anything else."""
+    try:
+        runpy.run_path(script, run_name="__main__")
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 0
+    except Exception:
+        return 0
+    return 0
+
+
+def _run_packaged(name: str, extra: list[str]) -> int:
+    """Run a guard shipped inside the installed klaussy package.
+
+    `name` is basenamed before lookup so a hook command can't walk out of the
+    templates directory. Fails open like every other path here.
+    """
+    try:
+        from importlib import resources
+
+        ref = resources.files("klaussy").joinpath(f"templates/hooks/{os.path.basename(name)}")
+        # as_file materializes the resource for the zipped-install case; for a
+        # normal install it hands back the real path unchanged.
+        with resources.as_file(ref) as path:
+            sys.argv = [str(path), *extra]
+            return _run(str(path))
+    except Exception:
+        return 0
+
+
 def main() -> int:
-    """Run the guard script named in argv[1], propagating its exit code.
+    """Run the guard named in argv[1], propagating its exit code.
 
     A guard blocks by exiting non-zero (2); it allows by exiting 0 or returning.
     Anything that prevents the guard from running (missing file, import error)
@@ -59,6 +95,10 @@ def main() -> int:
     """
     if len(sys.argv) < 2:
         return 0
+    if sys.argv[1] == "--packaged":
+        if len(sys.argv) < 3:
+            return 0
+        return _run_packaged(sys.argv[2], sys.argv[3:])
     if sys.argv[1] == "--repo-relative":
         if len(sys.argv) < 3:
             return 0
@@ -70,10 +110,4 @@ def main() -> int:
     # Present the guard with its own name as argv[0] and any trailing args, so a
     # guard that inspects sys.argv sees what it would under a direct invocation.
     sys.argv = [script, *sys.argv[2:]]
-    try:
-        runpy.run_path(script, run_name="__main__")
-    except SystemExit as exc:
-        return exc.code if isinstance(exc.code, int) else 0
-    except Exception:
-        return 0
-    return 0
+    return _run(script)

--- a/src/klaussy/hooks.py
+++ b/src/klaussy/hooks.py
@@ -41,7 +41,9 @@ COMMIT_GUARD_COMMAND = _cmd(COMMIT_GUARD_RELPATH)
 
 COMMENT_GUARD_SCRIPT_NAME = "comment_guard.py"
 COMMENT_GUARD_RELPATH = f".claude/hooks/{COMMENT_GUARD_SCRIPT_NAME}"
-COMMENT_GUARD_COMMAND = _cmd(COMMENT_GUARD_RELPATH)
+# Wired to the package, not a scaffolded copy: this guard bakes in nothing
+# repo-specific, and a copy only froze it at the scaffolding version.
+COMMENT_GUARD_COMMAND = f"klaussy-hook --packaged {COMMENT_GUARD_SCRIPT_NAME}"
 
 DEPENDENCY_GUARD_SCRIPT_NAME = "dependency_guard.py"
 DEPENDENCY_GUARD_RELPATH = f".claude/hooks/{DEPENDENCY_GUARD_SCRIPT_NAME}"
@@ -140,20 +142,6 @@ def _install_guard_script(repo: Path) -> Path:
     dest = repo / GUARD_RELPATH
     dest.parent.mkdir(parents=True, exist_ok=True)
     source = resources.files("klaussy").joinpath(f"templates/hooks/{GUARD_SCRIPT_NAME}")
-    dest.write_text(source.read_text())
-    mode = dest.stat().st_mode
-    dest.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    return dest
-
-
-def _install_comment_guard_script(repo: Path) -> Path:
-    """Copy the comment-humanizing guard into .claude/hooks/ and mark executable.
-
-    No commands are baked in: it shells out to `klaussy humanize` at run time, so
-    a plain copy is enough (unlike the commit guard's format/lint sentinels)."""
-    dest = repo / COMMENT_GUARD_RELPATH
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    source = resources.files("klaussy").joinpath(f"templates/hooks/{COMMENT_GUARD_SCRIPT_NAME}")
     dest.write_text(source.read_text())
     mode = dest.stat().st_mode
     dest.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
@@ -335,9 +323,9 @@ def scaffold_hooks(*, repo: Path, force: bool = False) -> Path:
     # plan itself.
     _install_guard_script(repo)
     _install_plan_guidance_script(repo, "claude")
-    # Comment guard rewrites an outgoing `gh` comment through `klaussy humanize`
-    # (PreToolUse updatedInput). No project-specific command, so always installed.
-    _install_comment_guard_script(repo)
+    # Drop the copy older versions scaffolded: the guard runs from the package
+    # now (see COMMENT_GUARD_COMMAND), and a leftover file reads as the live one.
+    (repo / COMMENT_GUARD_RELPATH).unlink(missing_ok=True)
     # Dependency gate blocks a `pip/npm/poetry/… install <pkg>` that adds a new
     # named dependency until the agent confirms it. No project-specific command,
     # so always installed.

--- a/src/klaussy/templates/hooks/comment_guard.py
+++ b/src/klaussy/templates/hooks/comment_guard.py
@@ -51,8 +51,9 @@ def _find_body(tokens: list[str]) -> tuple[int, str, bool] | None:
     return None
 
 
-# Shell operators that end one command and start the next.
-_SEPARATORS = ";&|"
+# Characters that end one command and start the next. A newline counts: agents
+# routinely send multi-line scripts as a single Bash call.
+_SEPARATORS = ";&|\n"
 
 
 def _split_commands(command: str) -> list[str]:

--- a/src/klaussy/templates/hooks/comment_guard.py
+++ b/src/klaussy/templates/hooks/comment_guard.py
@@ -2,29 +2,35 @@
 """PreToolUse guard: humanize a comment before the agent posts it.
 
 Installed by klaussy into .claude/hooks/ and registered in .claude/settings.json
-as a PreToolUse hook on `Bash`. When the agent is about to post a comment via
-`gh` (`gh pr comment`, `gh issue comment`, `gh pr review`), the guard extracts
-the comment body, runs it through klaussy's deterministic humanize scrubber, and
-— if the scrubber would change it — rewrites the command so the *posted* comment
-has no AI tells. The rewrite uses the PreToolUse `updatedInput` field, so it's
-transparent: Claude's command runs with the cleaned body, no extra round trip.
-
-Pure stdlib; the scrubbing itself shells out to `klaussy humanize` (stdin →
-stdout), the same canonical implementation the humanize skill and CLI use. If
-`klaussy` isn't on PATH, or the body isn't a plain literal, the guard allows the
-command unchanged — it never blocks a post on its own account.
+as a PreToolUse hook on `Bash`. A `--body` literal is rewritten through
+`updatedInput`, so the command runs cleaned with no extra round trip; a
+`--body-file` is scrubbed in place unless git reports it tracked, so a committed
+doc is never mutated. Pure stdlib; scrubbing shells out to `klaussy humanize`,
+the same implementation the skill and CLI use. If that isn't on PATH, or the
+body is neither a plain literal nor a readable file, the command runs unchanged.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 import sys
+from pathlib import Path
 
 # `gh` subcommands that post user-visible prose we want humanized.
-_COMMENT_SUBCOMMANDS = ("pr comment", "issue comment", "pr review")
+_COMMENT_SUBCOMMANDS = (
+    "pr comment",
+    "issue comment",
+    "pr review",
+    "pr create",
+    "pr edit",
+    "issue create",
+    "issue edit",
+)
 _BODY_FLAGS = ("-b", "--body")
+_BODY_FILE_FLAGS = ("-F", "--body-file")
 
 
 def _is_comment_post(command: str) -> bool:
@@ -45,6 +51,69 @@ def _find_body(tokens: list[str]) -> tuple[int, str, bool] | None:
     return None
 
 
+# Shell operators that end one command and start the next.
+_SEPARATORS = ";&|"
+
+
+def _split_commands(command: str) -> list[str]:
+    """Split a shell line into its separate commands, respecting quotes.
+
+    Segmenting has to happen on the raw string: shlex only emits a separator as
+    its own token when it's space-padded, so `gh pr comment 1 --body "x"; git
+    commit -F msg` leaves git's `-F` inside the gh segment and the guard scrubs
+    the commit message instead. Splitting on tokens that merely *contain* a
+    separator isn't an option either — a markdown table body is one quoted token
+    full of `|`.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(command):
+        ch = command[i]
+        if quote:
+            # Inside double quotes a backslash escapes the next character, so
+            # \" is body text and must not be read as the closing quote. Inside
+            # single quotes the shell treats a backslash literally, so it isn't.
+            if ch == chr(92) and quote == '"' and i + 1 < len(command):
+                buf.append(ch)
+                buf.append(command[i + 1])
+                i += 2
+                continue
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch == chr(92) and i + 1 < len(command):  # backslash escape
+            buf.append(ch)
+            buf.append(command[i + 1])
+            i += 2
+            continue
+        elif ch in "\"'":
+            quote = ch
+            buf.append(ch)
+        elif ch in _SEPARATORS:
+            parts.append("".join(buf))
+            buf = []
+            while i < len(command) and command[i] in _SEPARATORS:
+                i += 1
+            continue
+        else:
+            buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return [p for p in parts if p.strip()]
+
+
+def _find_body_file(tokens: list[str]) -> str | None:
+    """Locate the path passed to `--body-file` / `-F`, if any."""
+    for i, tok in enumerate(tokens):
+        if tok in _BODY_FILE_FLAGS and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if tok.startswith("--body-file="):
+            return tok[len("--body-file=") :]
+    return None
+
+
 def _humanize(text: str) -> str | None:
     """Scrub via `klaussy humanize`; None if it can't run (missing/failed)."""
     try:
@@ -56,11 +125,96 @@ def _humanize(text: str) -> str | None:
     return result.stdout
 
 
+def _is_untracked(path: str) -> bool | None:
+    """Whether the file is free of version control, so rewriting it is safe.
+
+    git runs with `-C` at the file's own directory, so the answer is about the
+    repo that owns the file rather than the agent's cwd. Only exit 0 (tracked)
+    stops a rewrite. git failing to run at all answers None rather than False,
+    so the caller can say the check didn't run instead of claiming the file is
+    tracked — either way we post unscrubbed rather than overwrite a doc the user
+    can't get back.
+    """
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    try:
+        result = subprocess.run(
+            ["git", "-C", directory, "ls-files", "--error-unmatch", "--", os.path.basename(path)],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode == 0:
+        return False  # git tracks it
+    if result.returncode == 1:
+        return True  # a repo that doesn't track it
+    if "not a git repository" in (result.stderr or "").lower():
+        return True  # nothing version-controls this directory
+    # Any other fatal (dubious ownership, unreadable index, a broken git
+    # wrapper) is git failing, not git answering. Treating it as untracked
+    # would overwrite a committed doc on the strength of an error.
+    return None
+
+
+def _write_atomic(path: Path, text: str) -> bool:
+    """Replace the file's contents atomically. False if the write failed.
+
+    A plain write truncates first, so a failure part-way through would hand `gh`
+    a half-written body to post.
+    """
+    tmp = path.with_name(path.name + ".klaussy-tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, path)
+        return True
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return False
+
+
+def _humanize_file(path: str) -> tuple[str, bool] | None:
+    """Scrub a `--body-file` in place.
+
+    Returns (note, scrubbed) when there's something to report. `scrubbed` is
+    True once the file holds the humanized body, and False when the body still
+    has tells and is about to post that way — the caller decides how loudly to
+    say so. None means there was nothing worth reporting.
+    """
+    if path == "-" or any(ch in path for ch in "$`"):
+        return None
+    try:
+        original = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    cleaned = _humanize(original)
+    if cleaned is None or cleaned == original:
+        return None
+    # The body has tells, so every outcome gets a note: staying quiet here reads
+    # as "already clean". Notes describe the file, never the command's fate —
+    # one caller allows the post and the other blocks it.
+    untracked = _is_untracked(path)
+    if untracked is None:
+        # Don't dress a missing git up as a version-control decision — the user
+        # needs to know the check couldn't run, not that the file is tracked.
+        return (
+            f"klaussy comment guard: couldn't check git for {path}, so it wasn't scrubbed.",
+            False,
+        )
+    if not untracked:
+        return (f"klaussy comment guard: {path} is tracked, so it wasn't scrubbed.", False)
+    if not _write_atomic(Path(path), cleaned):
+        return (f"klaussy comment guard: couldn't rewrite {path}, so it wasn't scrubbed.", False)
+    return (f"klaussy comment guard: humanized {path}.", True)
+
+
 def main() -> int:
     try:
         _raw = sys.stdin.buffer.read() if hasattr(sys.stdin, "buffer") else sys.stdin.read()
         payload = json.loads(_raw.decode("utf-8", "replace") if isinstance(_raw, bytes) else _raw)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
         return 0
 
     if (payload.get("hook_event_name") or payload.get("event")) != "PreToolUse":
@@ -73,39 +227,67 @@ def main() -> int:
     if not _is_comment_post(command):
         return 0
 
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        return 0
-    found = _find_body(tokens)
-    if not found:
-        return 0
-    idx, body, inline = found
+    parts = _split_commands(command)
+    notes: list[str] = []
 
-    # Only humanize plain literals — a body with shell expansion isn't ours to
-    # rewrite (we'd be scrubbing the template, not the rendered text).
-    if any(ch in body for ch in "$`"):
-        return 0
+    for part in parts:
+        if not _is_comment_post(part):
+            continue
+        try:
+            tokens = shlex.split(part)
+        except ValueError:
+            continue
 
-    cleaned = _humanize(body)
-    if cleaned is None or cleaned == body:
-        return 0
+        # File-backed body: fix the file, leave the command alone. Checked first
+        # because it's the shape anything multi-line actually uses, and because
+        # it needs no command rewrite, so chaining can't make it unsafe.
+        body_file = _find_body_file(tokens)
+        if body_file is not None:
+            reported = _humanize_file(body_file)
+            if reported:
+                notes.append(reported[0])
+            continue
 
-    new_tokens = list(tokens)
-    new_tokens[idx] = "--body=" + cleaned if inline else cleaned
-    new_command = shlex.join(new_tokens)
+        found = _find_body(tokens)
+        if found is None:
+            continue
+        idx, body, inline = found
+        # Only humanize plain literals — a body with shell expansion isn't ours
+        # to rewrite (we'd be scrubbing the template, not the rendered text).
+        if any(ch in body for ch in "$`"):
+            continue
+        cleaned = _humanize(body)
+        if cleaned is None or cleaned == body:
+            continue
 
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "allow",
-                    "updatedInput": {"command": new_command},
+        if len(parts) > 1:
+            # Rewriting one command out of a chained line means reassembling the
+            # others, and shlex.join doesn't round-trip the operators between
+            # them. Report rather than post a body we know has tells.
+            notes.append(
+                "klaussy comment guard: the body in this chained command has AI "
+                "tells and was left as-is. Post it as its own command, or write "
+                "it to a file and use --body-file, to have it humanized."
+            )
+            continue
+
+        new_tokens = list(tokens)
+        new_tokens[idx] = "--body=" + cleaned if inline else cleaned
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "allow",
+                        "updatedInput": {"command": shlex.join(new_tokens)},
+                    }
                 }
-            }
+            )
         )
-    )
+        return 0
+
+    if notes:
+        print(json.dumps({"systemMessage": " ".join(notes)}))
     return 0
 
 

--- a/src/klaussy/templates/hooks/multi/comment_guard.py
+++ b/src/klaussy/templates/hooks/multi/comment_guard.py
@@ -4,16 +4,12 @@
 Installed by klaussy into a target agent's hooks directory and wired to that
 agent's "before shell/tool" event (Gemini BeforeTool, Cursor
 beforeShellExecution, Codex PreToolUse, Copilot preToolUse, Antigravity
-run_command). When the agent is about to post a comment via `gh` (`gh pr
-comment`, `gh issue comment`, `gh pr review`), the guard scrubs the comment body
-with klaussy's deterministic humanizer.
-
-Unlike Claude's PreToolUse hook, these agents' protocols can't rewrite the tool
-input, so the guard can't humanize in place. Instead it BLOCKS the post (exit 2
-+ stderr, which every supported agent honors) and hands back the humanized
-command for the agent to re-issue. A body that's already clean — or one the
-guard can't scrub (no `klaussy` on PATH, shell-expanded body) — is allowed
-through untouched.
+run_command). A `--body-file` is scrubbed in place; a `--body` literal can't be
+rewritten under these protocols, so the guard BLOCKS the post (exit 2 + stderr,
+which every supported agent honors) and hands back the humanized command to
+re-issue — as it also does for a body it couldn't scrub at all (tracked file,
+failed write, git unavailable), since here a note on an allowed call may surface
+nowhere.
 
 Hardened to never crash: any unexpected payload or error exits 0 (allow), since
 some agents (e.g. Copilot preToolUse) treat a crashing hook as a deny of every
@@ -23,12 +19,23 @@ tool call. Pure stdlib; scrubbing shells out to `klaussy humanize`.
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 import sys
+from pathlib import Path
 
-_COMMENT_SUBCOMMANDS = ("pr comment", "issue comment", "pr review")
+_COMMENT_SUBCOMMANDS = (
+    "pr comment",
+    "issue comment",
+    "pr review",
+    "pr create",
+    "pr edit",
+    "issue create",
+    "issue edit",
+)
 _BODY_FLAGS = ("-b", "--body")
+_BODY_FILE_FLAGS = ("-F", "--body-file")
 
 
 def _extract_command(payload: dict) -> str:
@@ -60,6 +67,69 @@ def _find_body(tokens: list[str]) -> tuple[int, str, bool] | None:
     return None
 
 
+# Shell operators that end one command and start the next.
+_SEPARATORS = ";&|"
+
+
+def _split_commands(command: str) -> list[str]:
+    """Split a shell line into its separate commands, respecting quotes.
+
+    Segmenting has to happen on the raw string: shlex only emits a separator as
+    its own token when it's space-padded, so `gh pr comment 1 --body "x"; git
+    commit -F msg` leaves git's `-F` inside the gh segment and the guard scrubs
+    the commit message instead. Splitting on tokens that merely *contain* a
+    separator isn't an option either — a markdown table body is one quoted token
+    full of `|`.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(command):
+        ch = command[i]
+        if quote:
+            # Inside double quotes a backslash escapes the next character, so
+            # \" is body text and must not be read as the closing quote. Inside
+            # single quotes the shell treats a backslash literally, so it isn't.
+            if ch == chr(92) and quote == '"' and i + 1 < len(command):
+                buf.append(ch)
+                buf.append(command[i + 1])
+                i += 2
+                continue
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch == chr(92) and i + 1 < len(command):  # backslash escape
+            buf.append(ch)
+            buf.append(command[i + 1])
+            i += 2
+            continue
+        elif ch in "\"'":
+            quote = ch
+            buf.append(ch)
+        elif ch in _SEPARATORS:
+            parts.append("".join(buf))
+            buf = []
+            while i < len(command) and command[i] in _SEPARATORS:
+                i += 1
+            continue
+        else:
+            buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return [p for p in parts if p.strip()]
+
+
+def _find_body_file(tokens: list[str]) -> str | None:
+    """Locate the path passed to `--body-file` / `-F`, if any."""
+    for i, tok in enumerate(tokens):
+        if tok in _BODY_FILE_FLAGS and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if tok.startswith("--body-file="):
+            return tok[len("--body-file=") :]
+    return None
+
+
 def _humanize(text: str) -> str | None:
     try:
         result = subprocess.run(["klaussy", "humanize"], input=text, capture_output=True, text=True)
@@ -68,6 +138,97 @@ def _humanize(text: str) -> str | None:
     if result.returncode != 0:
         return None
     return result.stdout
+
+
+def _is_untracked(path: str) -> bool | None:
+    """Whether the file is free of version control, so rewriting it is safe.
+
+    git runs with `-C` at the file's own directory, so the answer is about the
+    repo that owns the file rather than the agent's cwd. Only exit 0 (tracked)
+    stops a rewrite. git failing to run at all answers None rather than False,
+    so the caller can say the check didn't run instead of claiming the file is
+    tracked — either way we post unscrubbed rather than overwrite a doc the user
+    can't get back.
+    """
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    try:
+        result = subprocess.run(
+            ["git", "-C", directory, "ls-files", "--error-unmatch", "--", os.path.basename(path)],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode == 0:
+        return False  # git tracks it
+    if result.returncode == 1:
+        return True  # a repo that doesn't track it
+    if "not a git repository" in (result.stderr or "").lower():
+        return True  # nothing version-controls this directory
+    # Any other fatal (dubious ownership, unreadable index, a broken git
+    # wrapper) is git failing, not git answering. Treating it as untracked
+    # would overwrite a committed doc on the strength of an error.
+    return None
+
+
+def _write_atomic(path: Path, text: str) -> bool:
+    """Replace the file's contents atomically. False if the write failed.
+
+    A plain write truncates first, so a failure part-way through would hand `gh`
+    a half-written body to post.
+    """
+    tmp = path.with_name(path.name + ".klaussy-tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, path)
+        return True
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return False
+
+
+def _humanize_file(path: str) -> tuple[str, bool] | None:
+    """Scrub a `--body-file` in place.
+
+    Returns (note, scrubbed) when there's something to report. `scrubbed` is
+    True once the file holds the humanized body, and False when the body still
+    has tells and is about to post that way — the caller decides how loudly to
+    say so. None means there was nothing worth reporting.
+    """
+    if path == "-" or any(ch in path for ch in "$`"):
+        return None
+    try:
+        original = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    cleaned = _humanize(original)
+    if cleaned is None or cleaned == original:
+        return None
+    # The body has tells, so every outcome gets a note: staying quiet here reads
+    # as "already clean". Notes describe the file, never the command's fate —
+    # one caller allows the post and the other blocks it.
+    untracked = _is_untracked(path)
+    if untracked is None:
+        # Don't dress a missing git up as a version-control decision — the user
+        # needs to know the check couldn't run, not that the file is tracked.
+        return (
+            f"klaussy comment guard: couldn't check git for {path}, so it wasn't scrubbed.",
+            False,
+        )
+    if not untracked:
+        return (f"klaussy comment guard: {path} is tracked, so it wasn't scrubbed.", False)
+    if not _write_atomic(Path(path), cleaned):
+        return (f"klaussy comment guard: couldn't rewrite {path}, so it wasn't scrubbed.", False)
+    return (f"klaussy comment guard: humanized {path}.", True)
+
+
+def _report(notes: list[str]) -> None:
+    """Surface every note collected this run; a blocked post still needs them."""
+    for note in notes:
+        print(note, file=sys.stderr)
 
 
 def main() -> int:
@@ -79,28 +240,74 @@ def main() -> int:
         command = _extract_command(payload)
         if not _is_comment_post(command):
             return 0
-        try:
-            tokens = shlex.split(command)
-        except ValueError:
-            return 0
-        found = _find_body(tokens)
-        if not found:
-            return 0
-        idx, body, inline = found
-        if any(ch in body for ch in "$`"):
-            return 0
-        cleaned = _humanize(body)
-        if cleaned is None or cleaned == body:
-            return 0
+        parts = _split_commands(command)
+        notes: list[str] = []
+        unscrubbed = False
 
-        new_tokens = list(tokens)
-        new_tokens[idx] = "--body=" + cleaned if inline else cleaned
-        print(
-            "klaussy comment guard: this comment has AI tells. Re-post the "
-            "humanized version:\n" + shlex.join(new_tokens),
-            file=sys.stderr,
-        )
-        return 2
+        for part in parts:
+            if not _is_comment_post(part):
+                continue
+            try:
+                tokens = shlex.split(part)
+            except ValueError:
+                continue
+
+            # File-backed body: fix the file, let the command through. No block
+            # needed, since `gh` reads the scrubbed file, and no command rewrite
+            # means chaining can't make this unsafe.
+            body_file = _find_body_file(tokens)
+            if body_file is not None:
+                reported = _humanize_file(body_file)
+                if reported:
+                    notes.append(reported[0])
+                    unscrubbed = unscrubbed or not reported[1]
+                continue
+
+            found = _find_body(tokens)
+            if found is None:
+                continue
+            idx, body, inline = found
+            if any(ch in body for ch in "$`"):
+                continue
+            cleaned = _humanize(body)
+            if cleaned is None or cleaned == body:
+                continue
+
+            if len(parts) > 1:
+                # Can't hand back a corrected line: shlex.join doesn't round-trip
+                # the operators between chained commands.
+                _report(notes)
+                print(
+                    "klaussy comment guard: this comment has AI tells. Post it as "
+                    "its own command (not chained) so it can be humanized, or "
+                    "write the body to a file and pass --body-file.",
+                    file=sys.stderr,
+                )
+                return 2
+
+            new_tokens = list(tokens)
+            new_tokens[idx] = "--body=" + cleaned if inline else cleaned
+            _report(notes)
+            print(
+                "klaussy comment guard: this comment has AI tells. Re-post the "
+                "humanized version:\n" + shlex.join(new_tokens),
+                file=sys.stderr,
+            )
+            return 2
+
+        _report(notes)
+        if unscrubbed:
+            # These agents only reliably surface a guard on the block channel
+            # (exit 2 + stderr), so a body we know still has tells has to block.
+            # Say the post didn't happen, or the agent moves on assuming it did.
+            print(
+                "klaussy comment guard: nothing was posted. Humanize the body "
+                "yourself, or point --body-file at a writable file outside "
+                "version control, then run the command again.",
+                file=sys.stderr,
+            )
+            return 2
+        return 0
     except Exception as exc:  # never crash — see module docstring
         print(f"klaussy comment guard error (allowing): {exc}", file=sys.stderr)
         return 0

--- a/src/klaussy/templates/hooks/multi/comment_guard.py
+++ b/src/klaussy/templates/hooks/multi/comment_guard.py
@@ -67,8 +67,9 @@ def _find_body(tokens: list[str]) -> tuple[int, str, bool] | None:
     return None
 
 
-# Shell operators that end one command and start the next.
-_SEPARATORS = ";&|"
+# Characters that end one command and start the next. A newline counts: agents
+# routinely send multi-line scripts as a single Bash call.
+_SEPARATORS = ";&|\n"
 
 
 def _split_commands(command: str) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1306,9 +1306,13 @@ class TestMultiAgentHooks:
             for h in entry["hooks"]
         ]
         assert cmds  # sanity
-        # Every command references the script via ${CLAUDE_PROJECT_DIR}, never a
-        # bare relative `.claude/hooks/...`.
-        assert all("${CLAUDE_PROJECT_DIR}/.claude/hooks/" in c for c in cmds)
+        # Every scaffolded guard names its script via ${CLAUDE_PROJECT_DIR}, never a
+        # bare relative path; the comment guard runs from the package, so it names none.
+        packaged = [c for c in cmds if "--packaged" in c]
+        assert packaged == ["klaussy-hook --packaged comment_guard.py"]
+        scaffolded = [c for c in cmds if "--packaged" not in c]
+        assert scaffolded
+        assert all("${CLAUDE_PROJECT_DIR}/.claude/hooks/" in c for c in scaffolded)
 
     def test_gemini_hook_commands_use_project_dir_env(self, repo: Path):
         from klaussy.agents.backends import GeminiBackend

--- a/tests/test_comment_guard.py
+++ b/tests/test_comment_guard.py
@@ -124,3 +124,254 @@ def test_multi_allows_when_clean(multi, monkeypatch):
 def test_multi_never_crashes_on_bad_stdin(multi, monkeypatch):
     monkeypatch.setattr(multi.sys, "stdin", io.StringIO("not json at all"))
     assert multi.main() == 0
+
+
+# --- file-backed bodies (--body-file / -F) --------------------------------
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_detects_pr_and_issue_bodies(mod_name, claude, multi):
+    """A PR/issue body is prose we post too, not just a comment."""
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    assert mod._is_comment_post("gh pr create --title t --body-file /tmp/b.md")
+    assert mod._is_comment_post("gh pr edit 38 --body-file /tmp/b.md")
+    assert mod._is_comment_post("gh issue create --title t -F /tmp/b.md")
+    assert not mod._is_comment_post("gh pr checkout 38")
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_find_body_file_forms(mod_name, claude, multi):
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    assert mod._find_body_file(shlex.split("gh pr comment 1 -F /tmp/b.md")) == "/tmp/b.md"
+    assert mod._find_body_file(shlex.split("gh pr create --body-file /tmp/b.md")) == "/tmp/b.md"
+    assert mod._find_body_file(shlex.split("gh pr create --body-file=/tmp/b.md")) == "/tmp/b.md"
+    assert mod._find_body_file(shlex.split('gh pr comment 1 --body "x"')) is None
+
+
+@pytest.fixture()
+def body_file(tmp_path):
+    path = tmp_path / "body.md"
+    path.write_text("A great solution — it works.", encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_body_file_is_scrubbed_in_place(mod_name, claude, multi, monkeypatch, body_file):
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    monkeypatch.setattr(mod, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(mod, "_is_untracked", lambda p: True)
+    note, scrubbed = mod._humanize_file(str(body_file))
+    assert scrubbed and "humanized" in note
+    assert body_file.read_text(encoding="utf-8") == "Clean version."
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_tracked_body_file_is_left_alone(mod_name, claude, multi, monkeypatch, body_file):
+    """Pointing --body-file at a committed doc must not mutate the repo."""
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    monkeypatch.setattr(mod, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(mod, "_is_untracked", lambda p: False)
+    note, scrubbed = mod._humanize_file(str(body_file))
+    assert not scrubbed and "is tracked" in note  # reported, not silently allowed
+    assert "—" in body_file.read_text(encoding="utf-8")  # left exactly as committed
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_unreadable_body_file_is_allowed(mod_name, claude, multi, monkeypatch, tmp_path):
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    monkeypatch.setattr(mod, "_humanize", lambda t: pytest.fail("should not run"))
+    assert mod._humanize_file(str(tmp_path / "missing.md")) is None
+    assert mod._humanize_file("-") is None
+    assert mod._humanize_file("$TMPDIR/body.md") is None
+
+
+def test_claude_scrubs_pr_body_file_and_notes_it(claude, monkeypatch, capsys, body_file):
+    monkeypatch.setattr(claude, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(claude, "_is_untracked", lambda p: True)
+    _feed(claude, monkeypatch, f"gh pr create --title t --body-file {body_file}")
+    assert claude.main() == 0
+    assert "humanized" in json.loads(capsys.readouterr().out)["systemMessage"]
+    assert body_file.read_text(encoding="utf-8") == "Clean version."
+
+
+def test_claude_body_file_stays_quiet_when_clean(claude, monkeypatch, capsys, body_file):
+    monkeypatch.setattr(claude, "_humanize", lambda t: t)
+    monkeypatch.setattr(claude, "_is_untracked", lambda p: True)
+    _feed(claude, monkeypatch, f"gh pr comment 1 --body-file {body_file}")
+    assert claude.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_multi_scrubs_body_file_without_blocking(multi, monkeypatch, body_file):
+    """The file is already fixed, so there's nothing to make the agent re-issue."""
+    monkeypatch.setattr(multi, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(multi, "_is_untracked", lambda p: True)
+    cmd = f"gh pr create --title t --body-file {body_file}"
+    monkeypatch.setattr(
+        multi.sys, "stdin", io.StringIO(json.dumps({"tool_input": {"command": cmd}}))
+    )
+    assert multi.main() == 0
+    assert body_file.read_text(encoding="utf-8") == "Clean version."
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_untracked_check_fails_closed(mod_name, claude, multi, monkeypatch):
+    """Only git saying it tracks the file (exit 0) stops a rewrite."""
+    mod = {"claude": claude, "multi": multi}[mod_name]
+
+    class _Result:
+        def __init__(self, code, stderr=""):
+            self.returncode = code
+            self.stderr = stderr
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _Result(1))
+    assert mod._is_untracked("/tmp/body.md") is True  # in a repo, not tracked
+    monkeypatch.setattr(
+        mod.subprocess, "run", lambda *a, **k: _Result(128, "fatal: not a git repository")
+    )
+    assert mod._is_untracked("/tmp/body.md") is True  # no repo owns it
+    monkeypatch.setattr(
+        mod.subprocess, "run", lambda *a, **k: _Result(128, "fatal: detected dubious ownership")
+    )
+    assert mod._is_untracked("README.md") is None  # git failed, it didn't answer
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _Result(0))
+    assert mod._is_untracked("README.md") is False  # tracked
+
+    def _boom(*a, **k):
+        raise OSError("no git")
+
+    monkeypatch.setattr(mod.subprocess, "run", _boom)
+    assert mod._is_untracked("README.md") is None  # git missing — can't tell
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_failed_write_leaves_original_intact(mod_name, claude, multi, monkeypatch, body_file):
+    """A part-way write must never hand `gh` a truncated body."""
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    monkeypatch.setattr(mod, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(mod, "_is_untracked", lambda p: True)
+
+    def _boom(self, *a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mod.Path, "write_text", _boom)
+    note, scrubbed = mod._humanize_file(str(body_file))
+    assert not scrubbed and "couldn't rewrite" in note  # reported, not silently allowed
+    assert body_file.read_text(encoding="utf-8") == "A great solution — it works."
+    assert not list(body_file.parent.glob("*.klaussy-tmp"))  # temp file cleaned up
+
+
+# --- chained commands: only the `gh` segment is ours -----------------------
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_split_commands_separates_chained_commands(mod_name, claude, multi):
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    # Unpadded separators glue into shlex tokens, so the split has to happen on
+    # the raw string: 'x;' would otherwise keep git's -F inside the gh command.
+    parts = mod._split_commands('gh pr comment 1 --body "x"; git commit -F /tmp/msg.txt')
+    assert len(parts) == 2
+    assert "/tmp/msg.txt" not in parts[0]
+    assert mod._is_comment_post(parts[0])
+    assert not mod._is_comment_post(parts[1])
+    assert len(mod._split_commands("gh pr comment 1 -b x&&git commit -F m")) == 2
+    # A separator inside quotes is body text, not an operator — markdown tables
+    # are full of pipes and must not split the command.
+    tabled = mod._split_commands('gh pr comment 1 --body "| a | b |\n| - | - |"')
+    assert len(tabled) == 1
+
+
+def test_claude_ignores_a_chained_commands_body_flag(claude, monkeypatch, capsys):
+    """`git commit -F msg` must not be mistaken for the comment body file."""
+    monkeypatch.setattr(claude, "_humanize", lambda t: "Clean.")
+    monkeypatch.setattr(
+        claude, "_humanize_file", lambda p: pytest.fail(f"scrubbed the wrong file: {p}")
+    )
+    _feed(
+        claude,
+        monkeypatch,
+        'git commit -F /tmp/msg.txt && gh pr comment 1 --body "A solution — it works."',
+    )
+    assert claude.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    # No rewrite: reassembling a chained line isn't safe. But it's reported, so
+    # the body with tells doesn't post in silence.
+    assert "hookSpecificOutput" not in out
+    assert "chained" in out["systemMessage"]
+
+
+def test_multi_ignores_a_chained_commands_body_flag(multi, monkeypatch, capsys):
+    monkeypatch.setattr(multi, "_humanize", lambda t: "Clean.")
+    monkeypatch.setattr(
+        multi, "_humanize_file", lambda p: pytest.fail(f"scrubbed the wrong file: {p}")
+    )
+    cmd = 'git commit -F /tmp/msg.txt && gh pr comment 1 --body "A solution — it works."'
+    monkeypatch.setattr(
+        multi.sys, "stdin", io.StringIO(json.dumps({"tool_input": {"command": cmd}}))
+    )
+    assert multi.main() == 2  # blocked, with the reason
+    err = capsys.readouterr().err
+    assert "its own command" in err
+    assert "/tmp/msg.txt" not in err  # git's file was never in scope
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_split_commands_handles_escaped_quotes(mod_name, claude, multi):
+    r"""An escaped \" inside a body must not be read as the closing quote."""
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    cmd = 'gh pr comment 1 --body "he said \\"hi\\"" && git commit -F /tmp/msg.txt'
+    parts = mod._split_commands(cmd)
+    assert len(parts) == 2
+    assert "/tmp/msg.txt" not in parts[0]
+    assert mod._find_body_file(shlex.split(parts[0])) is None  # git's -F stays git's
+    # A backslash inside single quotes is literal, so it must not eat the quote.
+    assert len(mod._split_commands("gh pr comment 1 --body 'a\\\\' ; git commit -F m")) == 2
+
+
+def test_multi_reports_collected_notes_when_it_blocks(multi, monkeypatch, capsys, body_file):
+    """A note from an earlier --body-file must survive a later block."""
+    monkeypatch.setattr(multi, "_humanize", lambda t: "Clean.")
+    monkeypatch.setattr(multi, "_is_untracked", lambda p: False)  # tracked → note only
+    cmd = f'gh pr comment 1 --body-file {body_file} && gh pr comment 2 --body "tells —"'
+    monkeypatch.setattr(
+        multi.sys, "stdin", io.StringIO(json.dumps({"tool_input": {"command": cmd}}))
+    )
+    assert multi.main() == 2
+    err = capsys.readouterr().err
+    assert "is tracked" in err  # the earlier note wasn't swallowed by the block
+    assert "its own command" in err
+
+
+@pytest.mark.parametrize("mod_name", ["claude", "multi"])
+def test_missing_git_is_reported_as_such(mod_name, claude, multi, monkeypatch, body_file):
+    """ "Couldn't check" must not be dressed up as "the file is tracked"."""
+    mod = {"claude": claude, "multi": multi}[mod_name]
+    monkeypatch.setattr(mod, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(mod, "_is_untracked", lambda p: None)
+    note, scrubbed = mod._humanize_file(str(body_file))
+    assert not scrubbed
+    assert "couldn't check git" in note
+    assert "is tracked" not in note
+
+
+def test_multi_blocks_when_a_body_file_posts_unscrubbed(multi, monkeypatch, capsys, body_file):
+    """A note on an allowed call may never surface, so an unscrubbed body blocks."""
+    monkeypatch.setattr(multi, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(multi, "_is_untracked", lambda p: False)  # tracked, left alone
+    cmd = f"gh pr comment 1 --body-file {body_file}"
+    monkeypatch.setattr(
+        multi.sys, "stdin", io.StringIO(json.dumps({"tool_input": {"command": cmd}}))
+    )
+    assert multi.main() == 2
+    assert "is tracked" in capsys.readouterr().err
+
+
+def test_multi_allows_quietly_when_the_body_file_was_scrubbed(multi, monkeypatch, body_file):
+    monkeypatch.setattr(multi, "_humanize", lambda t: "Clean version.")
+    monkeypatch.setattr(multi, "_is_untracked", lambda p: True)
+    cmd = f"gh pr comment 1 --body-file {body_file}"
+    monkeypatch.setattr(
+        multi.sys, "stdin", io.StringIO(json.dumps({"tool_input": {"command": cmd}}))
+    )
+    assert multi.main() == 0  # nothing to block: the file now holds clean text
+    assert body_file.read_text(encoding="utf-8") == "Clean version."

--- a/tests/test_comment_guard.py
+++ b/tests/test_comment_guard.py
@@ -275,6 +275,10 @@ def test_split_commands_separates_chained_commands(mod_name, claude, multi):
     assert mod._is_comment_post(parts[0])
     assert not mod._is_comment_post(parts[1])
     assert len(mod._split_commands("gh pr comment 1 -b x&&git commit -F m")) == 2
+    # A newline separates commands too — agents send multi-line Bash regularly.
+    newline_chained = mod._split_commands('gh pr comment 1 --body "x"\ngit commit -F /tmp/m')
+    assert len(newline_chained) == 2
+    assert mod._find_body_file(shlex.split(newline_chained[0])) is None
     # A separator inside quotes is body text, not an operator — markdown tables
     # are full of pipes and must not split the command.
     tabled = mod._split_commands('gh pr comment 1 --body "| a | b |\n| - | - |"')

--- a/tests/test_cross_platform.py
+++ b/tests/test_cross_platform.py
@@ -5,6 +5,7 @@ committed config back to a Unix-only form. See the README "Cross-platform"
 section for the per-agent support matrix.
 """
 
+import io
 import json
 import sys
 from pathlib import Path
@@ -155,4 +156,46 @@ def test_launcher_repo_relative_without_a_path_allows(monkeypatch, tmp_path: Pat
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sys, "argv", ["klaussy-hook", "--repo-relative"])
+    assert _hooklauncher.main() == 0
+
+
+# --- --packaged: guards that run from the installed package ----------------
+
+
+def _launch_packaged(name: str, monkeypatch, *extra: str) -> int:
+    from klaussy import _hooklauncher
+
+    monkeypatch.setattr(sys, "argv", ["klaussy-hook", "--packaged", name, *extra])
+    return _hooklauncher.main()
+
+
+def test_packaged_guard_runs_without_a_scaffolded_repo(monkeypatch, tmp_path, capsys):
+    """The whole point: the comment guard fires in a repo klaussy never touched."""
+    monkeypatch.chdir(tmp_path)  # no .claude/hooks/ anywhere
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": 'gh pr comment 1 --body "Let me know if you need anything else!"'
+        },
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    assert _launch_packaged("comment_guard.py", monkeypatch) == 0
+    out = capsys.readouterr().out
+    assert "updatedInput" in out  # the guard actually ran and rewrote the body
+
+
+def test_packaged_missing_guard_fails_open(monkeypatch):
+    assert _launch_packaged("no_such_guard.py", monkeypatch) == 0
+
+
+def test_packaged_rejects_path_traversal(monkeypatch):
+    # A name is basenamed before lookup, so it can't escape templates/hooks/.
+    assert _launch_packaged("../../../etc/passwd", monkeypatch) == 0
+
+
+def test_packaged_without_a_name_allows(monkeypatch):
+    from klaussy import _hooklauncher
+
+    monkeypatch.setattr(sys, "argv", ["klaussy-hook", "--packaged"])
     assert _hooklauncher.main() == 0

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -85,7 +85,9 @@ def test_settings_scaffolds_then_rerun_marks_skipped(repo: Path):
 def test_hooks_scaffolds_guards(repo: Path):
     result = toolkit.hooks(repo, agents=["claude"])
     assert result.ok
-    assert (repo / ".claude" / "hooks" / "comment_guard.py").exists()
+    assert (repo / ".claude" / "hooks" / "git_commit_guard.py").exists()
+    # comment guard runs from the package (see COMMENT_GUARD_COMMAND), no copy
+    assert not (repo / ".claude" / "hooks" / "comment_guard.py").exists()
 
 
 def test_claude_hook_commands_use_launcher():
@@ -126,3 +128,12 @@ def test_fix_and_test_skills_scope_to_base_branch(repo: Path):
     # fix/test scope to the branch diff, not the whole repo (substitution applied).
     assert "develop...HEAD" in fix.read_text()
     assert "develop...HEAD" in test.read_text()
+
+
+def test_hooks_removes_a_stale_comment_guard_copy(repo: Path):
+    """A repo scaffolded by an older klaussy keeps an inert copy — clear it."""
+    stale = repo / ".claude" / "hooks" / "comment_guard.py"
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_text("# scaffolded by an old klaussy\n")
+    assert toolkit.hooks(repo, agents=["claude"]).ok
+    assert not stale.exists()


### PR DESCRIPTION
## Summary

The comment guard was not humanizing anything in practice. Two independent failures: it was delivered as a per-repo copy that package upgrades never reach, and it did not recognize the command shapes that carry a PR or issue body. Both were silent, so the guard looked installed and did nothing.

## Changes

**Delivery.** klaussy ships fixes by having the package upgraded (klaussy-desktop runs `pipx upgrade klaussy-agents` on use), but the guard lived as a copy in each repo's `.claude/hooks/`, wired through `${CLAUDE_PROJECT_DIR}`. An upgrade never rewrote those copies, and the launcher exits 0 without a word when the copy is missing. Locally: package at 0.28.1, guards running at 0.6.0 / 0.12.2 / 0.20.0 / 0.27.0 / 0.28.0, and 8 of 13 repos with no guard at all.

- `klaussy-hook` gains a `--packaged <name>` mode resolving guards via `importlib.resources`; the name is basenamed against traversal and it fails open like the other paths.
- The comment guard is wired to it. It names no repo path, so it runs in every repo at the installed version, and an upgrade reaches all of them at once.
- Guards that bake in repo conventions stay per-repo copies: the commit guard's format/lint commands, the plan and self-review dialects. The comment guard baked in nothing, since it shells out to `klaussy humanize` at run time.
- `scaffold_hooks` removes the now-inert copy older versions wrote, so no repo keeps a stale file that reads as the live guard.

**Coverage.** Even correctly wired, the guard only parsed a body passed as one literal token on three subcommands. Across local transcripts, 40 of 43 `gh` posting calls used `--body-file`, and every `gh pr create` / `pr edit` body did.

- `--body-file` / `-F` bodies are scrubbed in place before `gh` reads them.
- `pr create`, `pr edit`, `issue create`, `issue edit` added to the subcommands that carry prose.
- Files git reports as tracked are never rewritten, so `--body-file README.md` cannot mutate the repo. A file git cannot answer for is left alone too.
- Writes go through a temp file and `os.replace`, so a failed write cannot hand `gh` a truncated body.
- Every outcome is reported. Returning quietly once we know a body has tells is indistinguishable from the body being clean, which is the failure the guard exists to prevent.
- Parsing is scoped to the `gh` command. `git commit -F msg.txt` chained onto a `gh` call was being read as the comment body, which meant scrubbing the commit message and posting the comment untouched. Splitting happens on the raw line, quote-aware, because `shlex` glues unpadded separators into tokens and a body holding a markdown table is one token full of pipes.

## Test Plan

- [x] Tests pass locally — 785 passed, 47 skipped; `ruff check` and `ruff format --check` clean
- [x] Manually verified

Verified end to end against the real scrubber, not mocks:

| Case | Result |
|---|---|
| `gh pr create --body-file` with a scratch body | scrubbed, note emitted |
| `--body-file README.md` (tracked) | untouched, md5 unchanged, reported |
| `gh pr comment ...; git commit -F msg.txt` | commit message untouched |
| body with escaped `\"` then a chained `git commit -F` | splits correctly, git's file out of scope |
| body containing a markdown table | not split, scrubbed normally |
| guard run in a directory with no `.claude/` | fires (this returned 0 in silence before) |

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] No unrelated changes
- [x] Tests added/updated for new functionality
- [ ] Documentation updated if needed

## Note for review

Stale repos still carry the old wiring in their own `.claude/settings.json` until something re-runs `klaussy init` there. This PR makes the guard correct and current wherever it runs; it does not by itself reach the 8 unscaffolded repos. That needs a separate decision about what triggers a re-scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
