### PR TITLE
feat(review): include Bitbucket forge in review skill templates

### DIFF
--- a/src/klaussy/templates/skills/review/SKILL.md
+++ b/src/klaussy/templates/skills/review/SKILL.md
@@ -61,7 +61,7 @@ Count the total **reviewable** lines changed (from Phase 1 step 3 — the trimme
 
 ## Small PR Review
 
-You are a senior/principal-level engineer reviewing a pull request. Treat this as a real production PR. Output ONLY PR-style review comments, as if leaving inline comments on GitHub/GitLab.
+You are a senior/principal-level engineer reviewing a pull request. Treat this as a real production PR. Output ONLY PR-style review comments, as if leaving inline comments on GitHub/GitLab/Bitbucket.
 
 ### Comment format (required for every comment):
 


### PR DESCRIPTION
## Summary

Updates review skill templates to recognize Bitbucket Cloud and Data Center / Server pull requests alongside GitHub and GitLab.

### Changes
- Updated `src/klaussy/templates/skills/review/SKILL.md` prompt instructions to support Bitbucket inline comments alongside GitHub and GitLab.

### Test Plan
- [x] Ran pytest test suite (`.venv/bin/pytest` -> 785 passed, 47 skipped).